### PR TITLE
Fix/io-standradization

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,19 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
+/// Build script for liiga_teletext
+///
+/// Note: This file intentionally uses synchronous std::fs operations because:
+/// - Build scripts run outside the normal async runtime
+/// - They execute during compilation, not during application runtime
+/// - Cargo expects build scripts to use blocking operations
+/// - There's no async runtime available in the build context
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let dir = out_dir.join("bin");
 
     // Create the bin directory if it doesn't exist
+    // Using std::fs here is correct for build scripts
     if !dir.exists() {
         fs::create_dir_all(&dir).unwrap();
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,7 +201,7 @@ mod tests {
 api_domain = "https://api.example.com"
 log_file_path = "/custom/log/path"
 "#;
-        fs::write(&config_path, config_content).unwrap();
+        tokio::fs::write(&config_path, config_content).await.unwrap();
 
         // Test loading from a specific path using the actual load_from_path method
         let config = Config::load_from_path(&config_path_str).await.unwrap();
@@ -220,7 +220,7 @@ log_file_path = "/custom/log/path"
         let config_content = r#"
 api_domain = "https://api.example.com"
 "#;
-        fs::write(&config_path, config_content).unwrap();
+        tokio::fs::write(&config_path, config_content).await.unwrap();
 
         // Test loading from a specific path using the actual load_from_path method
         let config = Config::load_from_path(&config_path_str).await.unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,7 +187,6 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
     use tempfile::tempdir;
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,7 +393,7 @@ async fn main() -> Result<(), AppError> {
 
     // Create log directory if it doesn't exist
     if !Path::new(&log_dir).exists() {
-        std::fs::create_dir_all(&log_dir).map_err(|e| {
+        tokio::fs::create_dir_all(&log_dir).await.map_err(|e| {
             AppError::log_setup_error(format!("Failed to create log directory: {}", e))
         })?;
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -4,7 +4,6 @@ use liiga_teletext::{
     teletext_ui::{GameResultData, TeletextPage},
 };
 use tempfile::tempdir;
-use tokio::fs;
 
 /// Test goal event data processing
 #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -209,10 +209,10 @@ async fn test_config_integration() {
 
     // Save config
     let config_content = toml::to_string_pretty(&test_config).unwrap();
-    fs::write(&config_path, config_content).await.unwrap();
+    tokio::fs::write(&config_path, config_content).await.unwrap();
 
     // Load config
-    let content = fs::read_to_string(&config_path).await.unwrap();
+    let content = tokio::fs::read_to_string(&config_path).await.unwrap();
     let loaded_config: Config = toml::from_str(&content).unwrap();
 
     // Verify config


### PR DESCRIPTION
- Deleted unnecessary `std::fs` import from `config.rs` and `tokio::fs` import from `integration_tests.rs` to clean up the codebase.
- This change improves code readability and maintains a focus on relevant dependencies.

## Description

<!-- Brief description of what this PR does and why it's needed -->

## Changes Made

## <!-- List the key changes you made -->

## Testing

<!-- How have you tested these changes? -->

- [ ] Local testing completed
- [ ] Unit tests added/updated (if applicable)

## Screenshots/Videos

<!-- If your changes include visual updates, add screenshots or videos -->
<!-- Delete this section if not applicable -->

## Additional Notes

<!-- Any additional information that reviewers should know? -->
<!-- Delete this section if not applicable -->

## Checklist

- [ ] Code follows project style guidelines
- [ ] Documentation has been updated (if needed)
- [ ] No new console warnings/errors
- [ ] Changes are responsive and work on different screen sizes (if applicable)
