### PR TITLE
Feat/show-past-season-games

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -528,8 +528,12 @@ another_extra = 123
 
             // Read back the saved config to verify the domain was processed correctly
             let content = tokio::fs::read_to_string(&config_path).await.unwrap();
-            assert!(content.contains(&format!("api_domain = \"{}\"", expected)),
-                    "Expected '{}' but content was: {}", expected, content);
+            assert!(
+                content.contains(&format!("api_domain = \"{}\"", expected)),
+                "Expected '{}' but content was: {}",
+                expected,
+                content
+            );
         }
     }
 
@@ -538,8 +542,14 @@ another_extra = 123
         let config_path = Config::get_config_path();
 
         // Verify the path structure
-        assert!(config_path.contains("liiga_teletext"), "Config path should contain app name");
-        assert!(config_path.ends_with("config.toml"), "Config path should end with config.toml");
+        assert!(
+            config_path.contains("liiga_teletext"),
+            "Config path should contain app name"
+        );
+        assert!(
+            config_path.ends_with("config.toml"),
+            "Config path should end with config.toml"
+        );
 
         // Verify it's a valid path (doesn't test if it exists, just that it's a valid path format)
         let path = std::path::Path::new(&config_path);
@@ -551,8 +561,14 @@ another_extra = 123
         let log_dir_path = Config::get_log_dir_path();
 
         // Verify the path structure
-        assert!(log_dir_path.contains("liiga_teletext"), "Log dir path should contain app name");
-        assert!(log_dir_path.ends_with("logs"), "Log dir path should end with logs");
+        assert!(
+            log_dir_path.contains("liiga_teletext"),
+            "Log dir path should contain app name"
+        );
+        assert!(
+            log_dir_path.ends_with("logs"),
+            "Log dir path should end with logs"
+        );
 
         // Verify it's a valid path
         let path = std::path::Path::new(&log_dir_path);
@@ -563,7 +579,8 @@ another_extra = 123
     async fn test_config_save_creates_nested_directories() {
         // Test that save_to_path creates nested directories
         let temp_dir = tempdir().unwrap();
-        let nested_path = temp_dir.path()
+        let nested_path = temp_dir
+            .path()
             .join("level1")
             .join("level2")
             .join("level3")

--- a/src/data_fetcher/api.rs
+++ b/src/data_fetcher/api.rs
@@ -1,8 +1,8 @@
 use crate::config::Config;
 use crate::data_fetcher::cache::{cache_players_with_formatting, get_cached_players};
 use crate::data_fetcher::models::{
-    DetailedGame, DetailedGameResponse, DetailedTeam, GameData, GoalEvent, GoalEventData, Player, ScheduleApiGame,
-    ScheduleGame, ScheduleResponse, ScheduleTeam,
+    DetailedGame, DetailedGameResponse, DetailedTeam, GameData, GoalEvent, GoalEventData, Player,
+    ScheduleApiGame, ScheduleGame, ScheduleResponse, ScheduleTeam,
 };
 use crate::data_fetcher::player_names::{build_full_name, format_for_display};
 use crate::data_fetcher::processors::{
@@ -1033,7 +1033,10 @@ fn parse_date_and_season(date: &str) -> (i32, u32, i32) {
     // Ice hockey season: if month >= 9, season = year+1, else season = year
     let season = if month >= 9 { year + 1 } else { year };
 
-    info!("Parsed date: year={}, month={}, season={}", year, month, season);
+    info!(
+        "Parsed date: year={}, month={}, season={}",
+        year, month, season
+    );
     (year, month, season)
 }
 
@@ -1041,7 +1044,10 @@ fn parse_date_and_season(date: &str) -> (i32, u32, i32) {
 fn determine_tournaments_for_month(month: u32) -> Vec<TournamentType> {
     let tournaments = if (PLAYOFFS_START_MONTH..=PLAYOFFS_END_MONTH).contains(&month) {
         // Spring months (March-June): check playoffs, playout, qualifications, and runkosarja
-        info!("Spring month {} detected, checking all tournament types", month);
+        info!(
+            "Spring month {} detected, checking all tournament types",
+            month
+        );
         vec![
             TournamentType::Runkosarja,
             TournamentType::Playoffs,
@@ -1050,18 +1056,27 @@ fn determine_tournaments_for_month(month: u32) -> Vec<TournamentType> {
         ]
     } else if (PRESEASON_START_MONTH..=PRESEASON_END_MONTH).contains(&month) {
         // Preseason months (May-September): check valmistavat_ottelut and runkosarja
-        info!("Preseason month {} detected, checking valmistavat_ottelut and runkosarja", month);
+        info!(
+            "Preseason month {} detected, checking valmistavat_ottelut and runkosarja",
+            month
+        );
         vec![
             TournamentType::Runkosarja,
             TournamentType::ValmistavatOttelut,
         ]
     } else {
         // Regular season months: only check runkosarja
-        info!("Regular season month {} detected, checking only runkosarja", month);
+        info!(
+            "Regular season month {} detected, checking only runkosarja",
+            month
+        );
         vec![TournamentType::Runkosarja]
     };
 
-    info!("Tournaments to check: {:?}", tournaments.iter().map(|t| t.as_str()).collect::<Vec<_>>());
+    info!(
+        "Tournaments to check: {:?}",
+        tournaments.iter().map(|t| t.as_str()).collect::<Vec<_>>()
+    );
     tournaments
 }
 
@@ -1073,13 +1088,18 @@ async fn fetch_tournament_games(
     tournaments: &[TournamentType],
     season: i32,
 ) -> Vec<ScheduleApiGame> {
-    info!("Fetching games from {} tournaments for season {}", tournaments.len(), season);
+    info!(
+        "Fetching games from {} tournaments for season {}",
+        tournaments.len(),
+        season
+    );
 
     // Create futures for parallel execution to leverage connection pooling
     let fetch_futures: Vec<_> = tournaments
         .iter()
         .map(|tournament| {
-            let url = build_tournament_schedule_url(&config.api_domain, tournament.as_str(), season);
+            let url =
+                build_tournament_schedule_url(&config.api_domain, tournament.as_str(), season);
             let tournament_name = tournament.as_str();
 
             async move {
@@ -1159,7 +1179,10 @@ fn filter_games_by_date(games: Vec<ScheduleApiGame>, target_date: &str) -> Vec<S
                     let tournament = TournamentType::from_serie(game.serie);
                     info!(
                         "Found matching game: {} vs {} on {} (tournament: {})",
-                        game.home_team_name, game.away_team_name, date_part, tournament.as_str()
+                        game.home_team_name,
+                        game.away_team_name,
+                        date_part,
+                        tournament.as_str()
                     );
                 }
                 matches
@@ -1477,7 +1500,8 @@ async fn fetch_detailed_game_data_for_historical_game(
                 &response.game,
                 &response.home_team_players,
                 &response.away_team_players,
-            ).await;
+            )
+            .await;
 
             DetailedGameData {
                 home_goals: response.game.home_team.goals,
@@ -1595,8 +1619,6 @@ async fn process_goal_events_for_historical_game_with_players(
     all_goal_events.sort_by_key(|event| event.minute);
     all_goal_events
 }
-
-
 
 /// Enhanced struct to hold game data including goal events and detailed game information
 struct DetailedGameData {
@@ -2371,13 +2393,11 @@ mod tests {
             },
         ];
 
-        let away_players = vec![
-            Player {
-                id: 789,
-                first_name: "David".to_string(),
-                last_name: "Brown".to_string(),
-            },
-        ];
+        let away_players = vec![Player {
+            id: 789,
+            first_name: "David".to_string(),
+            last_name: "Brown".to_string(),
+        }];
 
         // Create test game with goal events
         let game = DetailedGame {
@@ -2423,21 +2443,19 @@ mod tests {
                 team_id: "team2".to_string(),
                 team_name: "Tappara".to_string(),
                 goals: 1,
-                goal_events: vec![
-                    GoalEvent {
-                        scorer_player_id: 789,
-                        log_time: "2024-01-15T19:30:00Z".to_string(),
-                        game_time: 3000,
-                        period: 2,
-                        event_id: 3,
-                        home_team_score: 1,
-                        away_team_score: 1,
-                        winning_goal: false,
-                        goal_types: vec!["even_strength".to_string()],
-                        assistant_player_ids: vec![],
-                        video_clip_url: None,
-                    },
-                ],
+                goal_events: vec![GoalEvent {
+                    scorer_player_id: 789,
+                    log_time: "2024-01-15T19:30:00Z".to_string(),
+                    game_time: 3000,
+                    period: 2,
+                    event_id: 3,
+                    home_team_score: 1,
+                    away_team_score: 1,
+                    winning_goal: false,
+                    goal_types: vec!["even_strength".to_string()],
+                    assistant_player_ids: vec![],
+                    video_clip_url: None,
+                }],
                 penalty_events: vec![],
             },
             periods: vec![],
@@ -2453,7 +2471,8 @@ mod tests {
             &game,
             &home_players,
             &away_players,
-        ).await;
+        )
+        .await;
 
         // Verify results
         assert_eq!(goal_events.len(), 3);
@@ -2491,13 +2510,11 @@ mod tests {
         use crate::data_fetcher::models::{DetailedGame, DetailedTeam, GoalEvent, Player};
 
         // Create test players (missing player ID 999)
-        let home_players = vec![
-            Player {
-                id: 123,
-                first_name: "John".to_string(),
-                last_name: "Smith".to_string(),
-            },
-        ];
+        let home_players = vec![Player {
+            id: 123,
+            first_name: "John".to_string(),
+            last_name: "Smith".to_string(),
+        }];
 
         let away_players = vec![];
 
@@ -2511,21 +2528,19 @@ mod tests {
                 team_id: "team1".to_string(),
                 team_name: "HIFK".to_string(),
                 goals: 1,
-                goal_events: vec![
-                    GoalEvent {
-                        scorer_player_id: 999, // Missing player
-                        log_time: "2024-01-15T19:15:00Z".to_string(),
-                        game_time: 2700,
-                        period: 2,
-                        event_id: 1,
-                        home_team_score: 1,
-                        away_team_score: 0,
-                        winning_goal: false,
-                        goal_types: vec!["even_strength".to_string()],
-                        assistant_player_ids: vec![],
-                        video_clip_url: None,
-                    },
-                ],
+                goal_events: vec![GoalEvent {
+                    scorer_player_id: 999, // Missing player
+                    log_time: "2024-01-15T19:15:00Z".to_string(),
+                    game_time: 2700,
+                    period: 2,
+                    event_id: 1,
+                    home_team_score: 1,
+                    away_team_score: 0,
+                    winning_goal: false,
+                    goal_types: vec!["even_strength".to_string()],
+                    assistant_player_ids: vec![],
+                    video_clip_url: None,
+                }],
                 penalty_events: vec![],
             },
             away_team: DetailedTeam {
@@ -2548,7 +2563,8 @@ mod tests {
             &game,
             &home_players,
             &away_players,
-        ).await;
+        )
+        .await;
 
         // Verify results
         assert_eq!(goal_events.len(), 1);
@@ -2559,7 +2575,7 @@ mod tests {
         assert_eq!(goal_event.is_home_team, true);
     }
 
-        // Tests for is_historical_date function
+    // Tests for is_historical_date function
     #[test]
     fn test_is_historical_date_august_transition() {
         // Mock current date as August 2024
@@ -2569,18 +2585,39 @@ mod tests {
 
         // Test August transition scenario: current_month is 8, date_month is between 5-7
         // These should be historical (from previous season)
-        assert!(is_historical_date_with_current_time("2024-05-15", current_time)); // May 2024 in August 2024
-        assert!(is_historical_date_with_current_time("2024-06-20", current_time)); // June 2024 in August 2024
-        assert!(is_historical_date_with_current_time("2024-07-10", current_time)); // July 2024 in August 2024
+        assert!(is_historical_date_with_current_time(
+            "2024-05-15",
+            current_time
+        )); // May 2024 in August 2024
+        assert!(is_historical_date_with_current_time(
+            "2024-06-20",
+            current_time
+        )); // June 2024 in August 2024
+        assert!(is_historical_date_with_current_time(
+            "2024-07-10",
+            current_time
+        )); // July 2024 in August 2024
 
         // These should NOT be historical (same season)
-        assert!(!is_historical_date_with_current_time("2024-08-15", current_time)); // August 2024 in August 2024
-        assert!(!is_historical_date_with_current_time("2024-09-01", current_time)); // September 2024 in August 2024
-        assert!(!is_historical_date_with_current_time("2024-12-25", current_time)); // December 2024 in August 2024
-        assert!(!is_historical_date_with_current_time("2024-03-15", current_time)); // March 2024 in August 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-08-15",
+            current_time
+        )); // August 2024 in August 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-09-01",
+            current_time
+        )); // September 2024 in August 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-12-25",
+            current_time
+        )); // December 2024 in August 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-03-15",
+            current_time
+        )); // March 2024 in August 2024
     }
 
-            #[test]
+    #[test]
     fn test_is_historical_date_year_boundary() {
         // Test year boundary cases
         // Mock current date as January 2023
@@ -2590,22 +2627,34 @@ mod tests {
 
         // Date in September 2022 compared to current date in January 2023
         // This should be historical (previous year)
-        assert!(is_historical_date_with_current_time("2022-09-15", current_time)); // September 2022
+        assert!(is_historical_date_with_current_time(
+            "2022-09-15",
+            current_time
+        )); // September 2022
 
         // Date in April 2022 compared to current date in January 2023
         // This should be historical (previous year)
-        assert!(is_historical_date_with_current_time("2022-04-15", current_time)); // April 2022
+        assert!(is_historical_date_with_current_time(
+            "2022-04-15",
+            current_time
+        )); // April 2022
 
         // Date in January 2023 compared to current date in January 2023
         // This should NOT be historical (current year, same month)
-        assert!(!is_historical_date_with_current_time("2023-01-15", current_time)); // January 2023
+        assert!(!is_historical_date_with_current_time(
+            "2023-01-15",
+            current_time
+        )); // January 2023
 
         // Date in December 2022 compared to current date in January 2023
         // This should be historical (previous year)
-        assert!(is_historical_date_with_current_time("2022-12-15", current_time)); // December 2022
+        assert!(is_historical_date_with_current_time(
+            "2022-12-15",
+            current_time
+        )); // December 2022
     }
 
-        #[test]
+    #[test]
     fn test_is_historical_date_off_season_months() {
         // Test off-season months where current_month is between 5-7
         // and date_month is between 9-4 (regular season months)
@@ -2616,22 +2665,55 @@ mod tests {
             .with_timezone(&Local);
 
         // These should be historical (from previous season)
-        assert!(is_historical_date_with_current_time("2023-09-15", current_time)); // September 2023 in June 2024
-        assert!(is_historical_date_with_current_time("2023-10-20", current_time)); // October 2023 in June 2024
-        assert!(is_historical_date_with_current_time("2023-11-10", current_time)); // November 2023 in June 2024
-        assert!(is_historical_date_with_current_time("2023-12-25", current_time)); // December 2023 in June 2024
-        assert!(is_historical_date_with_current_time("2024-01-15", current_time)); // January 2024 in June 2024
-        assert!(is_historical_date_with_current_time("2024-02-20", current_time)); // February 2024 in June 2024
-        assert!(is_historical_date_with_current_time("2024-03-10", current_time)); // March 2024 in June 2024
-        assert!(is_historical_date_with_current_time("2024-04-15", current_time)); // April 2024 in June 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-09-15",
+            current_time
+        )); // September 2023 in June 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-10-20",
+            current_time
+        )); // October 2023 in June 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-11-10",
+            current_time
+        )); // November 2023 in June 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-12-25",
+            current_time
+        )); // December 2023 in June 2024
+        assert!(is_historical_date_with_current_time(
+            "2024-01-15",
+            current_time
+        )); // January 2024 in June 2024
+        assert!(is_historical_date_with_current_time(
+            "2024-02-20",
+            current_time
+        )); // February 2024 in June 2024
+        assert!(is_historical_date_with_current_time(
+            "2024-03-10",
+            current_time
+        )); // March 2024 in June 2024
+        assert!(is_historical_date_with_current_time(
+            "2024-04-15",
+            current_time
+        )); // April 2024 in June 2024
 
         // These should NOT be historical (same off-season)
-        assert!(!is_historical_date_with_current_time("2024-05-15", current_time)); // May 2024 in June 2024
-        assert!(!is_historical_date_with_current_time("2024-06-20", current_time)); // June 2024 in June 2024
-        assert!(!is_historical_date_with_current_time("2024-07-10", current_time)); // July 2024 in June 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-05-15",
+            current_time
+        )); // May 2024 in June 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-06-20",
+            current_time
+        )); // June 2024 in June 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-07-10",
+            current_time
+        )); // July 2024 in June 2024
     }
 
-            #[test]
+    #[test]
     fn test_is_historical_date_regular_season_months() {
         // Test regular season months that should return false
         // during both in-season and off-season periods
@@ -2642,32 +2724,71 @@ mod tests {
             .with_timezone(&Local);
 
         // These should NOT be historical (current year)
-        assert!(!is_historical_date_with_current_time("2024-09-15", current_time)); // September 2024 in December 2024
-        assert!(!is_historical_date_with_current_time("2024-10-20", current_time)); // October 2024 in December 2024
-        assert!(!is_historical_date_with_current_time("2024-11-10", current_time)); // November 2024 in December 2024
-        assert!(!is_historical_date_with_current_time("2024-12-25", current_time)); // December 2024 in December 2024
-        assert!(!is_historical_date_with_current_time("2025-01-15", current_time)); // January 2025 in December 2024
-        assert!(!is_historical_date_with_current_time("2025-02-20", current_time)); // February 2025 in December 2024
-        assert!(!is_historical_date_with_current_time("2025-03-10", current_time)); // March 2025 in December 2024
-        assert!(!is_historical_date_with_current_time("2025-04-15", current_time)); // April 2025 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-09-15",
+            current_time
+        )); // September 2024 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-10-20",
+            current_time
+        )); // October 2024 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-11-10",
+            current_time
+        )); // November 2024 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-12-25",
+            current_time
+        )); // December 2024 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2025-01-15",
+            current_time
+        )); // January 2025 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2025-02-20",
+            current_time
+        )); // February 2025 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2025-03-10",
+            current_time
+        )); // March 2025 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2025-04-15",
+            current_time
+        )); // April 2025 in December 2024
 
         // These should be historical (previous year)
-        assert!(is_historical_date_with_current_time("2023-09-15", current_time)); // September 2023 in December 2024
-        assert!(is_historical_date_with_current_time("2023-12-25", current_time)); // December 2023 in December 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-09-15",
+            current_time
+        )); // September 2023 in December 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-12-25",
+            current_time
+        )); // December 2023 in December 2024
         // Note: January 2024 and April 2024 are NOT historical when current time is December 2024
         // because they are in the same year and the off-season condition doesn't apply
-        assert!(!is_historical_date_with_current_time("2024-01-15", current_time)); // January 2024 in December 2024
-        assert!(!is_historical_date_with_current_time("2024-04-15", current_time)); // April 2024 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-01-15",
+            current_time
+        )); // January 2024 in December 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-04-15",
+            current_time
+        )); // April 2024 in December 2024
     }
 
-            #[test]
+    #[test]
     fn test_is_historical_date_edge_cases() {
         // Test edge cases and invalid inputs
         // Use current time for edge case tests
         let current_time = Utc::now().with_timezone(&Local);
 
         // Invalid date format should return false
-        assert!(!is_historical_date_with_current_time("invalid-date", current_time));
+        assert!(!is_historical_date_with_current_time(
+            "invalid-date",
+            current_time
+        ));
         assert!(!is_historical_date_with_current_time("2024", current_time));
         assert!(!is_historical_date_with_current_time("", current_time));
 
@@ -2677,15 +2798,27 @@ mod tests {
             .unwrap()
             .with_timezone(&Local);
 
-        assert!(!is_historical_date_with_current_time("2024-08-15", specific_current_time)); // August in August (same month)
-        assert!(!is_historical_date_with_current_time("2024-09-01", specific_current_time)); // September in August (next month)
+        assert!(!is_historical_date_with_current_time(
+            "2024-08-15",
+            specific_current_time
+        )); // August in August (same month)
+        assert!(!is_historical_date_with_current_time(
+            "2024-09-01",
+            specific_current_time
+        )); // September in August (next month)
 
         // Future dates should not be historical
-        assert!(!is_historical_date_with_current_time("2025-01-15", specific_current_time)); // Future year
-        assert!(!is_historical_date_with_current_time("2024-12-31", specific_current_time)); // Future month in same year
+        assert!(!is_historical_date_with_current_time(
+            "2025-01-15",
+            specific_current_time
+        )); // Future year
+        assert!(!is_historical_date_with_current_time(
+            "2024-12-31",
+            specific_current_time
+        )); // Future month in same year
     }
 
-            #[test]
+    #[test]
     fn test_is_historical_date_complex_scenarios() {
         // Test complex scenarios that might occur in real usage
 
@@ -2696,16 +2829,34 @@ mod tests {
             .with_timezone(&Local);
 
         // Regular season games from current year should NOT be historical
-        assert!(!is_historical_date_with_current_time("2024-10-15", current_time_april)); // October 2024 in April 2024
-        assert!(!is_historical_date_with_current_time("2024-12-25", current_time_april)); // December 2024 in April 2024
-        assert!(!is_historical_date_with_current_time("2024-02-20", current_time_april)); // February 2024 in April 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-10-15",
+            current_time_april
+        )); // October 2024 in April 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-12-25",
+            current_time_april
+        )); // December 2024 in April 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-02-20",
+            current_time_april
+        )); // February 2024 in April 2024
 
         // Regular season games from previous year should be historical
-        assert!(is_historical_date_with_current_time("2023-10-15", current_time_april)); // October 2023 in April 2024
-        assert!(is_historical_date_with_current_time("2023-12-25", current_time_april)); // December 2023 in April 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-10-15",
+            current_time_april
+        )); // October 2023 in April 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-12-25",
+            current_time_april
+        )); // December 2023 in April 2024
         // Note: January 2024 is NOT historical when current time is April 2024
         // because they are in the same year and the off-season condition doesn't apply
-        assert!(!is_historical_date_with_current_time("2024-01-20", current_time_april)); // January 2024 in April 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-01-20",
+            current_time_april
+        )); // January 2024 in April 2024
 
         // Scenario 2: During preseason (September 2024), looking at previous season
         // Mock current date as September 2024
@@ -2714,14 +2865,29 @@ mod tests {
             .with_timezone(&Local);
 
         // Previous year games should be historical
-        assert!(is_historical_date_with_current_time("2023-10-15", current_time_september)); // October 2023 in September 2024
+        assert!(is_historical_date_with_current_time(
+            "2023-10-15",
+            current_time_september
+        )); // October 2023 in September 2024
         // April 2024 is NOT historical in September 2024
-        assert!(!is_historical_date_with_current_time("2024-04-15", current_time_september)); // April 2024 in September 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-04-15",
+            current_time_september
+        )); // April 2024 in September 2024
         // May 2024 is NOT historical in September 2024
-        assert!(!is_historical_date_with_current_time("2024-05-20", current_time_september)); // May 2024 in September 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-05-20",
+            current_time_september
+        )); // May 2024 in September 2024
 
         // Current year games should NOT be historical
-        assert!(!is_historical_date_with_current_time("2024-09-20", current_time_september)); // September 2024 in September 2024
-        assert!(!is_historical_date_with_current_time("2024-10-15", current_time_september)); // October 2024 in September 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-09-20",
+            current_time_september
+        )); // September 2024 in September 2024
+        assert!(!is_historical_date_with_current_time(
+            "2024-10-15",
+            current_time_september
+        )); // October 2024 in September 2024
     }
 }

--- a/src/data_fetcher/api.rs
+++ b/src/data_fetcher/api.rs
@@ -1210,10 +1210,6 @@ fn is_historical_date(date: &str) -> bool {
         return true;
     } else if date_year == current_year {
         // Same year, check if it's in the off-season
-        // If current month is May-July (5-7) and date is also May-July, it's from previous season
-        if current_month >= 5 && current_month <= 7 && date_month >= 5 && date_month <= 7 {
-            return true;
-        }
         // If current month is August (8) and date is May-July, it's from previous season
         if current_month == 8 && date_month >= 5 && date_month <= 7 {
             return true;

--- a/src/data_fetcher/models.rs
+++ b/src/data_fetcher/models.rs
@@ -348,7 +348,10 @@ mod tests {
         assert_eq!(deserialized.game_time, 900);
         assert_eq!(deserialized.goal_types, vec!["EV"]);
         assert_eq!(deserialized.assistant_player_ids, vec![67890, 11111]);
-        assert_eq!(deserialized.video_clip_url, Some("https://example.com/video.mp4".to_string()));
+        assert_eq!(
+            deserialized.video_clip_url,
+            Some("https://example.com/video.mp4".to_string())
+        );
     }
 
     #[test]
@@ -499,7 +502,10 @@ mod tests {
         // Test deserialization
         let deserialized: ScheduleResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.games.len(), 1);
-        assert_eq!(deserialized.previous_game_date, Some("2024-01-14".to_string()));
+        assert_eq!(
+            deserialized.previous_game_date,
+            Some("2024-01-14".to_string())
+        );
         assert_eq!(deserialized.next_game_date, Some("2024-01-16".to_string()));
     }
 
@@ -681,20 +687,16 @@ mod tests {
                 serie: "runkosarja".to_string(),
             },
             awards: vec![],
-            home_team_players: vec![
-                Player {
-                    id: 123,
-                    last_name: "Koivu".to_string(),
-                    first_name: "Mikko".to_string(),
-                }
-            ],
-            away_team_players: vec![
-                Player {
-                    id: 456,
-                    last_name: "Selänne".to_string(),
-                    first_name: "Teemu".to_string(),
-                }
-            ],
+            home_team_players: vec![Player {
+                id: 123,
+                last_name: "Koivu".to_string(),
+                first_name: "Mikko".to_string(),
+            }],
+            away_team_players: vec![Player {
+                id: 456,
+                last_name: "Selänne".to_string(),
+                first_name: "Teemu".to_string(),
+            }],
         };
 
         // Test serialization
@@ -762,7 +764,10 @@ mod tests {
         assert!(goal_event_data.is_winning_goal);
         assert_eq!(goal_event_data.goal_types, vec!["YV", "MV"]);
         assert!(goal_event_data.is_home_team);
-        assert_eq!(goal_event_data.video_clip_url, Some("https://example.com/video.mp4".to_string()));
+        assert_eq!(
+            goal_event_data.video_clip_url,
+            Some("https://example.com/video.mp4".to_string())
+        );
     }
 
     #[test]
@@ -907,7 +912,10 @@ mod tests {
         assert!(goal_event.winning_goal);
         assert_eq!(goal_event.goal_types, vec!["YV", "MV", "RV"]);
         assert_eq!(goal_event.assistant_player_ids, vec![11111, 22222, 33333]);
-        assert_eq!(goal_event.video_clip_url, Some("https://video.example.com/goal/54321.mp4".to_string()));
+        assert_eq!(
+            goal_event.video_clip_url,
+            Some("https://video.example.com/goal/54321.mp4".to_string())
+        );
     }
 
     #[test]

--- a/src/data_fetcher/processors.rs
+++ b/src/data_fetcher/processors.rs
@@ -198,10 +198,16 @@ pub fn format_time(timestamp: &str) -> Result<String, AppError> {
 pub fn create_basic_goal_events(game: &ScheduleGame) -> Vec<GoalEventData> {
     let mut basic_names = HashMap::new();
     for goal in &game.home_team.goal_events {
-        basic_names.insert(goal.scorer_player_id, create_fallback_name(goal.scorer_player_id));
+        basic_names.insert(
+            goal.scorer_player_id,
+            create_fallback_name(goal.scorer_player_id),
+        );
     }
     for goal in &game.away_team.goal_events {
-        basic_names.insert(goal.scorer_player_id, create_fallback_name(goal.scorer_player_id));
+        basic_names.insert(
+            goal.scorer_player_id,
+            create_fallback_name(goal.scorer_player_id),
+        );
     }
     process_goal_events(game, &basic_names)
 }
@@ -209,8 +215,7 @@ pub fn create_basic_goal_events(game: &ScheduleGame) -> Vec<GoalEventData> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data_fetcher::models::{GoalEvent, ScheduleTeam, ScheduleGame};
-
+    use crate::data_fetcher::models::{GoalEvent, ScheduleGame, ScheduleTeam};
 
     fn create_test_goal_event(
         scorer_player_id: i64,
@@ -324,7 +329,8 @@ mod tests {
         let cancelled_goal_rl0 = create_test_goal_event(456, 900, 1, 0, vec!["RL0".to_string()]);
         let cancelled_goal_vt0 = create_test_goal_event(789, 1200, 1, 0, vec!["VT0".to_string()]);
 
-        let team = create_test_team_with_goals(vec![valid_goal, cancelled_goal_rl0, cancelled_goal_vt0]);
+        let team =
+            create_test_team_with_goals(vec![valid_goal, cancelled_goal_rl0, cancelled_goal_vt0]);
         let mut player_names = HashMap::new();
         player_names.insert(123, "Koivu".to_string());
         player_names.insert(456, "Cancelled1".to_string());
@@ -497,7 +503,7 @@ mod tests {
         assert!(events.is_empty());
     }
 
-        #[test]
+    #[test]
     fn test_goal_event_data_fields() {
         let goal = create_test_goal_event(123, 900, 2, 1, vec!["YV".to_string(), "MV".to_string()]);
         let game = create_test_game(vec![], vec![goal]);
@@ -517,7 +523,10 @@ mod tests {
         assert!(!event.is_winning_goal);
         assert_eq!(event.goal_types, vec!["YV", "MV"]);
         assert!(!event.is_home_team); // Away team goal
-        assert_eq!(event.video_clip_url, Some("https://example.com/video.mp4".to_string()));
+        assert_eq!(
+            event.video_clip_url,
+            Some("https://example.com/video.mp4".to_string())
+        );
     }
 
     #[test]
@@ -542,7 +551,7 @@ mod tests {
             600,
             1,
             0,
-            vec!["YV".to_string(), "RV".to_string(), "MV".to_string()]
+            vec!["YV".to_string(), "RV".to_string(), "MV".to_string()],
         );
 
         let game = create_test_game(vec![complex_goal], vec![]);

--- a/src/error.rs
+++ b/src/error.rs
@@ -250,91 +250,137 @@ mod tests {
     fn test_config_error_helper() {
         let error = AppError::config_error("Invalid configuration");
         assert!(matches!(error, AppError::Config(_)));
-        assert_eq!(error.to_string(), "Configuration error: Invalid configuration");
+        assert_eq!(
+            error.to_string(),
+            "Configuration error: Invalid configuration"
+        );
     }
 
     #[test]
     fn test_datetime_parse_error_helper() {
         let error = AppError::datetime_parse_error("Invalid date format");
         assert!(matches!(error, AppError::DateTimeParse(_)));
-        assert_eq!(error.to_string(), "Date/time parsing error: Invalid date format");
+        assert_eq!(
+            error.to_string(),
+            "Date/time parsing error: Invalid date format"
+        );
     }
 
     #[test]
     fn test_log_setup_error_helper() {
         let error = AppError::log_setup_error("Failed to initialize logger");
         assert!(matches!(error, AppError::LogSetup(_)));
-        assert_eq!(error.to_string(), "Log setup error: Failed to initialize logger");
+        assert_eq!(
+            error.to_string(),
+            "Log setup error: Failed to initialize logger"
+        );
     }
 
     #[test]
     fn test_api_not_found_helper() {
         let error = AppError::api_not_found("https://api.example.com/games/123");
         assert!(matches!(error, AppError::ApiNotFound { .. }));
-        assert_eq!(error.to_string(), "API request not found (404): https://api.example.com/games/123");
+        assert_eq!(
+            error.to_string(),
+            "API request not found (404): https://api.example.com/games/123"
+        );
     }
 
     #[test]
     fn test_api_server_error_helper() {
-        let error = AppError::api_server_error(500, "Internal server error", "https://api.example.com");
+        let error =
+            AppError::api_server_error(500, "Internal server error", "https://api.example.com");
         assert!(matches!(error, AppError::ApiServerError { .. }));
-        assert_eq!(error.to_string(), "API server error (500): Internal server error (URL: https://api.example.com)");
+        assert_eq!(
+            error.to_string(),
+            "API server error (500): Internal server error (URL: https://api.example.com)"
+        );
     }
 
     #[test]
     fn test_api_client_error_helper() {
         let error = AppError::api_client_error(400, "Bad request", "https://api.example.com");
         assert!(matches!(error, AppError::ApiClientError { .. }));
-        assert_eq!(error.to_string(), "API client error (400): Bad request (URL: https://api.example.com)");
+        assert_eq!(
+            error.to_string(),
+            "API client error (400): Bad request (URL: https://api.example.com)"
+        );
     }
 
     #[test]
     fn test_api_rate_limit_helper() {
         let error = AppError::api_rate_limit("Too many requests", "https://api.example.com");
         assert!(matches!(error, AppError::ApiRateLimit { .. }));
-        assert_eq!(error.to_string(), "API rate limit exceeded (429): Too many requests (URL: https://api.example.com)");
+        assert_eq!(
+            error.to_string(),
+            "API rate limit exceeded (429): Too many requests (URL: https://api.example.com)"
+        );
     }
 
     #[test]
     fn test_api_service_unavailable_helper() {
-        let error = AppError::api_service_unavailable(503, "Service unavailable", "https://api.example.com");
+        let error = AppError::api_service_unavailable(
+            503,
+            "Service unavailable",
+            "https://api.example.com",
+        );
         assert!(matches!(error, AppError::ApiServiceUnavailable { .. }));
-        assert_eq!(error.to_string(), "API service unavailable (503): Service unavailable (URL: https://api.example.com)");
+        assert_eq!(
+            error.to_string(),
+            "API service unavailable (503): Service unavailable (URL: https://api.example.com)"
+        );
     }
 
     #[test]
     fn test_network_timeout_helper() {
         let error = AppError::network_timeout("https://api.example.com");
         assert!(matches!(error, AppError::NetworkTimeout { .. }));
-        assert_eq!(error.to_string(), "Network timeout while fetching data from: https://api.example.com");
+        assert_eq!(
+            error.to_string(),
+            "Network timeout while fetching data from: https://api.example.com"
+        );
     }
 
     #[test]
     fn test_network_connection_helper() {
         let error = AppError::network_connection("https://api.example.com", "Connection refused");
         assert!(matches!(error, AppError::NetworkConnection { .. }));
-        assert_eq!(error.to_string(), "Connection failed to: https://api.example.com - Connection refused");
+        assert_eq!(
+            error.to_string(),
+            "Connection failed to: https://api.example.com - Connection refused"
+        );
     }
 
     #[test]
     fn test_api_malformed_json_helper() {
-        let error = AppError::api_malformed_json("Invalid JSON structure", "https://api.example.com");
+        let error =
+            AppError::api_malformed_json("Invalid JSON structure", "https://api.example.com");
         assert!(matches!(error, AppError::ApiMalformedJson { .. }));
-        assert_eq!(error.to_string(), "API returned malformed JSON: Invalid JSON structure (URL: https://api.example.com)");
+        assert_eq!(
+            error.to_string(),
+            "API returned malformed JSON: Invalid JSON structure (URL: https://api.example.com)"
+        );
     }
 
     #[test]
     fn test_api_unexpected_structure_helper() {
-        let error = AppError::api_unexpected_structure("Missing required field", "https://api.example.com");
+        let error =
+            AppError::api_unexpected_structure("Missing required field", "https://api.example.com");
         assert!(matches!(error, AppError::ApiUnexpectedStructure { .. }));
-        assert_eq!(error.to_string(), "API returned unexpected data structure: Missing required field (URL: https://api.example.com)");
+        assert_eq!(
+            error.to_string(),
+            "API returned unexpected data structure: Missing required field (URL: https://api.example.com)"
+        );
     }
 
     #[test]
     fn test_api_no_data_helper() {
         let error = AppError::api_no_data("Empty response", "https://api.example.com");
         assert!(matches!(error, AppError::ApiNoData { .. }));
-        assert_eq!(error.to_string(), "API returned empty or missing data: Empty response (URL: https://api.example.com)");
+        assert_eq!(
+            error.to_string(),
+            "API returned empty or missing data: Empty response (URL: https://api.example.com)"
+        );
     }
 
     #[test]
@@ -348,14 +394,20 @@ mod tests {
     fn test_api_game_not_found_helper() {
         let error = AppError::api_game_not_found(123, 2024);
         assert!(matches!(error, AppError::ApiGameNotFound { .. }));
-        assert_eq!(error.to_string(), "Game not found: game_id=123, season=2024");
+        assert_eq!(
+            error.to_string(),
+            "Game not found: game_id=123, season=2024"
+        );
     }
 
     #[test]
     fn test_api_tournament_not_found_helper() {
         let error = AppError::api_tournament_not_found("runkosarja", "2024-01-15");
         assert!(matches!(error, AppError::ApiTournamentNotFound { .. }));
-        assert_eq!(error.to_string(), "Tournament not found: runkosarja for date 2024-01-15");
+        assert_eq!(
+            error.to_string(),
+            "Tournament not found: runkosarja for date 2024-01-15"
+        );
     }
 
     #[test]
@@ -390,7 +442,7 @@ mod tests {
         assert!(!AppError::api_malformed_json("message", "url").is_not_found());
     }
 
-        #[test]
+    #[test]
     fn test_error_from_reqwest() {
         // Test that reqwest errors are properly converted
         // Create a reqwest error by using an invalid URL in a request
@@ -422,7 +474,7 @@ mod tests {
         assert!(matches!(app_error, AppError::Io(_)));
     }
 
-        #[test]
+    #[test]
     fn test_error_from_toml_serialize() {
         // Test that TOML serialization errors are properly converted
         // Create a struct that will fail to serialize
@@ -439,7 +491,9 @@ mod tests {
             Err(serde::ser::Error::custom("Serialization failed"))
         }
 
-        let bad_struct = BadStruct { field: "test".to_string() };
+        let bad_struct = BadStruct {
+            field: "test".to_string(),
+        };
         let toml_error = toml::to_string(&bad_struct).unwrap_err();
         let app_error: AppError = toml_error.into();
         assert!(matches!(app_error, AppError::TomlSerialize(_)));
@@ -494,9 +548,17 @@ mod tests {
 
         for error in errors {
             let display_string = error.to_string();
-            assert!(!display_string.is_empty(), "Error display should not be empty: {:?}", error);
+            assert!(
+                !display_string.is_empty(),
+                "Error display should not be empty: {:?}",
+                error
+            );
             // Ensure the display string contains some meaningful content
-            assert!(display_string.len() > 5, "Error display should be descriptive: {:?}", error);
+            assert!(
+                display_string.len() > 5,
+                "Error display should be descriptive: {:?}",
+                error
+            );
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,7 +290,12 @@ async fn create_future_games_page(
 async fn check_latest_version() -> Option<String> {
     let crates_io_url = format!("https://crates.io/api/v1/crates/{CRATE_NAME}");
 
-    let client = reqwest::Client::new();
+    // Create a properly configured HTTP client with timeout handling
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10)) // Shorter timeout for update checks
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new()); // Fallback to default client if builder fails
+
     let user_agent = format!("{CRATE_NAME}/{CURRENT_VERSION}");
     let response = match client
         .get(&crates_io_url)

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,15 +116,17 @@ fn get_subheader(games: &[GameData]) -> String {
     if games.is_empty() {
         return "SM-LIIGA".to_string();
     }
-
-    // Use the tournament type from the first game as they should all be from same tournament
-    match games[0].serie.as_str() {
-        "PLAYOFFS" => "PLAYOFFS".to_string(),
-        "PLAYOUT" => "PLAYOUT-OTTELUT".to_string(),
-        "QUALIFICATIONS" => "LIIGAKARSINTA".to_string(),
-        "valmistavat_ottelut" => "HARJOITUSOTTELUT".to_string(),
-        "PRACTICE" => "HARJOITUSOTTELUT".to_string(),
-        _ => "RUNKOSARJA".to_string(),
+    // Priority: PLAYOFFS > PLAYOUT-OTTELUT > LIIGAKARSINTA > HARJOITUSOTTELUT > RUNKOSARJA
+    if games.iter().any(|g| g.serie.eq_ignore_ascii_case("playoffs")) {
+        "PLAYOFFS".to_string()
+    } else if games.iter().any(|g| g.serie.eq_ignore_ascii_case("playout")) {
+        "PLAYOUT-OTTELUT".to_string()
+    } else if games.iter().any(|g| g.serie.eq_ignore_ascii_case("qualifications")) {
+        "LIIGAKARSINTA".to_string()
+    } else if games.iter().any(|g| g.serie.eq_ignore_ascii_case("valmistavat_ottelut") || g.serie.eq_ignore_ascii_case("practice")) {
+        "HARJOITUSOTTELUT".to_string()
+    } else {
+        "RUNKOSARJA".to_string()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,16 +117,28 @@ fn get_subheader(games: &[GameData]) -> String {
         return "SM-LIIGA".to_string();
     }
     // Priority: PLAYOFFS > PLAYOUT-OTTELUT > LIIGAKARSINTA > HARJOITUSOTTELUT > RUNKOSARJA
-    if games.iter().any(|g| g.serie.eq_ignore_ascii_case("playoffs")) {
-        "PLAYOFFS".to_string()
-    } else if games.iter().any(|g| g.serie.eq_ignore_ascii_case("playout")) {
-        "PLAYOUT-OTTELUT".to_string()
-    } else if games.iter().any(|g| g.serie.eq_ignore_ascii_case("qualifications")) {
-        "LIIGAKARSINTA".to_string()
-    } else if games.iter().any(|g| g.serie.eq_ignore_ascii_case("valmistavat_ottelut") || g.serie.eq_ignore_ascii_case("practice")) {
-        "HARJOITUSOTTELUT".to_string()
-    } else {
-        "RUNKOSARJA".to_string()
+    let mut priority = 4; // Default to RUNKOSARJA
+    for game in games {
+        let serie_lower = game.serie.to_ascii_lowercase();
+        let current_priority = match serie_lower.as_str() {
+            "playoffs" => 0,
+            "playout" => 1,
+            "qualifications" => 2,
+            "valmistavat_ottelut" | "practice" => 3,
+            _ => 4,
+        };
+        if current_priority < priority {
+            priority = current_priority;
+            if priority == 0 { break; } // Found highest priority
+        }
+    }
+
+    match priority {
+        0 => "PLAYOFFS".to_string(),
+        1 => "PLAYOUT-OTTELUT".to_string(),
+        2 => "LIIGAKARSINTA".to_string(),
+        3 => "HARJOITUSOTTELUT".to_string(),
+        _ => "RUNKOSARJA".to_string(),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,9 @@ fn get_subheader(games: &[GameData]) -> String {
         };
         if current_priority < priority {
             priority = current_priority;
-            if priority == 0 { break; } // Found highest priority
+            if priority == 0 {
+                break;
+            } // Found highest priority
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ async fn create_base_page(
     show_footer: bool,
     ignore_height_limit: bool,
     future_games_header: Option<String>,
+    fetched_date: Option<String>,
 ) -> TeletextPage {
     let subheader = get_subheader(games);
     let mut page = TeletextPage::new(
@@ -146,6 +147,11 @@ async fn create_base_page(
         show_footer,
         ignore_height_limit,
     );
+
+    // Set the fetched date if provided
+    if let Some(date) = fetched_date {
+        page.set_fetched_date(date);
+    }
 
     // Add future games header first if provided
     if let Some(header) = future_games_header {
@@ -167,6 +173,7 @@ async fn create_page(
     disable_video_links: bool,
     show_footer: bool,
     ignore_height_limit: bool,
+    fetched_date: Option<String>,
 ) -> TeletextPage {
     create_base_page(
         games,
@@ -174,6 +181,7 @@ async fn create_page(
         show_footer,
         ignore_height_limit,
         None,
+        fetched_date,
     )
     .await
 }
@@ -248,6 +256,7 @@ async fn create_future_games_page(
             show_footer,
             ignore_height_limit,
             future_games_header,
+            None, // No fetched date for future games
         )
         .await;
 
@@ -606,7 +615,16 @@ async fn main() -> Result<(), AppError> {
             .await
             {
                 Some(page) => page,
-                None => create_page(&games, args.disable_links, true, true).await,
+                None => {
+                    create_page(
+                        &games,
+                        args.disable_links,
+                        true,
+                        true,
+                        Some(fetched_date.clone()),
+                    )
+                    .await
+                }
             }
         };
 
@@ -746,7 +764,16 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
                     .await
                     {
                         Some(page) => page,
-                        None => create_page(&games, args.disable_links, true, false).await,
+                        None => {
+                            create_page(
+                                &games,
+                                args.disable_links,
+                                true,
+                                false,
+                                Some(fetched_date.clone()),
+                            )
+                            .await
+                        }
                     }
                 };
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -362,3 +362,35 @@ async fn test_special_situations() {
     assert_eq!(overtime_game.result, "3-2");
     assert!(overtime_game.is_overtime); // Should have overtime
 }
+
+/// Test fetched date display in header
+#[tokio::test]
+async fn test_fetched_date_display() {
+    // Create teletext page
+    let mut page = TeletextPage::new(
+        221,
+        "JÄÄKIEKKO".to_string(),
+        "RUNKOSARJA".to_string(),
+        false,
+        true,
+        false,
+    );
+
+    // Test without fetched date (should not show date in header)
+    // This simulates current date view
+    assert!(page.get_fetched_date().is_none());
+
+    // Test with fetched date (should show date in header)
+    let historical_date = "15.01.2024".to_string();
+    page.set_fetched_date(historical_date.clone());
+
+    // Verify fetched date was set correctly
+    assert_eq!(page.get_fetched_date(), Some(&historical_date));
+
+    // Test with different date format
+    let another_date = "23.12.2023".to_string();
+    page.set_fetched_date(another_date.clone());
+
+    // Verify fetched date was updated correctly
+    assert_eq!(page.get_fetched_date(), Some(&another_date));
+}


### PR DESCRIPTION
- Removed redundant checks for historical dates in the `is_historical_date` function within `api.rs`, specifically the conditions related to May-July dates.
- Streamlined the logic to enhance clarity and maintainability while ensuring accurate historical date evaluations.

## Description

<!-- Brief description of what this PR does and why it's needed -->

## Changes Made

## <!-- List the key changes you made -->

## Testing

<!-- How have you tested these changes? -->

- [ ] Local testing completed
- [ ] Unit tests added/updated (if applicable)

## Screenshots/Videos

<!-- If your changes include visual updates, add screenshots or videos -->
<!-- Delete this section if not applicable -->

## Additional Notes

<!-- Any additional information that reviewers should know? -->
<!-- Delete this section if not applicable -->

## Checklist

- [ ] Code follows project style guidelines
- [ ] Documentation has been updated (if needed)
- [ ] No new console warnings/errors
- [ ] Changes are responsive and work on different screen sizes (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for fetching and displaying historical hockey game data for previous seasons.
  * Teletext pages now show the date for which data was fetched, formatted in the header when available.

* **Enhancements**
  * Improved subheader logic to prioritize tournament types by importance across all games for clearer context.
  * Enhanced HTTP client configuration with connection pooling, timeout, and HTTP/2 support for data fetching and version checking.

* **Bug Fixes**
  * None.

* **Tests**
  * Added unit and integration tests to verify the correct display and updating of the fetched date on teletext pages.
  * Added tests covering historical date detection and goal event processing with player lookup.

* **Style**
  * Reformatted assertions, struct initializations, and method chaining in test code for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->