### PR TITLE
fix: improve cache management and responsiveness for starting games

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,11 +13,14 @@ pub const HTTP_POOL_MAX_IDLE_PER_HOST: usize = 100;
 
 /// Cache TTL (Time To Live) values in seconds
 pub mod cache_ttl {
-    /// TTL for live games (30 seconds for reasonable clock tracking)
-    pub const LIVE_GAMES_SECONDS: u64 = 30;
+    /// TTL for live games (reduced from 30 to 15 seconds for more responsive updates)
+    pub const LIVE_GAMES_SECONDS: u64 = 15;
 
     /// TTL for completed games (1 hour)
     pub const COMPLETED_GAMES_SECONDS: u64 = 3600;
+
+    /// TTL for games that should be starting soon (5 minutes before to 10 minutes after scheduled start)
+    pub const STARTING_GAMES_SECONDS: u64 = 10;
 
     /// TTL for player data (24 hours)
     pub const PLAYER_DATA_SECONDS: u64 = 86400;


### PR DESCRIPTION
- Reduced the cache TTL for live games from 30 seconds to 15 seconds, enhancing the responsiveness of updates during ongoing games.
- Introduced a new TTL for games that should be starting soon, set to 10 seconds, to ensure fresh data is fetched for games near their scheduled start time.
- Updated the cache invalidation logic to aggressively clear entries for games that are near their start time, improving data accuracy.
- Enhanced the auto-refresh interval for ongoing games to 15 seconds and added a specific interval for games close to starting, ensuring timely updates.

These changes contribute to a more responsive and accurate representation of live game data in the application.
