### PR TITLE
feat: implement rate limiting protection and adaptive refresh intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ liiga_teletext/
 - `-d, --date <DATE>` - Show games for a specific date in YYYY-MM-DD format
 - `-o, --once` - Show scores once and exit immediately (useful for scripts)
 - `-p, --plain` - Disable clickable video links in the output
+- `--min-refresh-interval <SECONDS>` - Set minimum refresh interval in seconds (default: auto-detect based on game count). Higher values reduce API calls but may miss updates. Use with caution.
 
 #### Configuration
 - `-c, --config [DOMAIN]` - Update API domain in config (prompts if not provided)
@@ -167,6 +168,7 @@ The application includes several performance optimizations:
 - **HTTP Response Caching**: Intelligent caching with time-based expiration reduces API calls
 - **Request Deduplication**: Prevents multiple identical API calls from running simultaneously
 - **Performance Metrics**: Tracks API call counts, cache hit rates, and response times
+- **Rate Limiting Protection**: Adaptive refresh intervals based on game count with exponential backoff
 - **Connection Pooling**: Reuses HTTP connections for better performance
 - **Incremental Updates**: Only refreshes data when necessary based on game state
 - **Memory Management**: Efficient data structures and resource cleanup
@@ -194,6 +196,9 @@ The application includes several performance optimizations:
 - [x] Request deduplication to prevent duplicate API calls
 - [x] Performance metrics collection and monitoring
 - [x] Emergency cache management for memory optimization
+- [x] Rate limiting protection with exponential backoff
+- [x] Adaptive refresh intervals based on game count
+- [x] Configurable minimum refresh intervals
 - [x] Robust error handling with user-friendly messages
 - [x] Comprehensive test coverage with testing utilities
 - [x] Advanced UI components with interactive features

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,15 +13,15 @@ pub const HTTP_POOL_MAX_IDLE_PER_HOST: usize = 100;
 
 /// Cache TTL (Time To Live) values in seconds
 pub mod cache_ttl {
-    /// TTL for live games (optimized to 8 seconds for very responsive live updates)
-    pub const LIVE_GAMES_SECONDS: u64 = 8;
+    /// TTL for live games (increased from 8 to 15 seconds to reduce API calls)
+    pub const LIVE_GAMES_SECONDS: u64 = 15;
 
     /// TTL for completed games (1 hour)
     pub const COMPLETED_GAMES_SECONDS: u64 = 3600;
 
-    /// TTL for games that should be starting soon (5 minutes before to 10 minutes after scheduled start)
-    /// This should be the most aggressive refresh rate to catch the exact moment games become live
-    pub const STARTING_GAMES_SECONDS: u64 = 5;
+    /// TTL for games that should be starting soon (increased from 5 to 30 seconds to reduce API calls)
+    /// This should still catch the moment games become live but with less aggressive polling
+    pub const STARTING_GAMES_SECONDS: u64 = 30;
 
     /// TTL for player data (24 hours)
     pub const PLAYER_DATA_SECONDS: u64 = 86400;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -145,15 +145,16 @@ mod tests {
 
     #[test]
     fn test_ttl_constants_are_reasonable() {
-        // Test that TTL values make sense relative to each other
+        // Test that TTL constants make sense for rate limiting
         let live = cache_ttl::LIVE_GAMES_SECONDS;
         let starting = cache_ttl::STARTING_GAMES_SECONDS;
         let completed = cache_ttl::COMPLETED_GAMES_SECONDS;
         let player = cache_ttl::PLAYER_DATA_SECONDS;
         let http = cache_ttl::HTTP_RESPONSE_SECONDS;
 
-        // Starting games should have the shortest TTL (most aggressive refresh)
-        assert!(starting < live);
+        // With rate limiting protection, starting games can have longer TTL than live games
+        // to reduce API calls while still catching the moment games become live
+        assert!(starting >= live); // Starting games TTL >= live games TTL
         // Live games should have shorter TTL than completed games
         assert!(live < completed);
         // Completed games should have shorter TTL than player data
@@ -162,8 +163,8 @@ mod tests {
         assert!(http > 0);
 
         // Ensure starting games TTL is reasonable (not too short, not too long)
-        assert!(starting >= 5); // At least 5 seconds
-        assert!(starting <= 30); // At most 30 seconds
+        assert!(starting >= 15); // At least 15 seconds (same as live games)
+        assert!(starting <= 60); // At most 60 seconds (increased from 30)
     }
 
     #[test]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,8 +13,9 @@ pub const HTTP_POOL_MAX_IDLE_PER_HOST: usize = 100;
 
 /// Cache TTL (Time To Live) values in seconds
 pub mod cache_ttl {
-    /// TTL for live games (increased from 8 to 15 seconds to reduce API calls)
-    pub const LIVE_GAMES_SECONDS: u64 = 15;
+    /// TTL for live games (reduced from 15 to 8 seconds to ensure fresh goal events)
+    /// This should be shorter than the auto-refresh interval (15s) to prevent stale data
+    pub const LIVE_GAMES_SECONDS: u64 = 8;
 
     /// TTL for completed games (1 hour)
     pub const COMPLETED_GAMES_SECONDS: u64 = 3600;

--- a/src/data_fetcher/api.rs
+++ b/src/data_fetcher/api.rs
@@ -439,23 +439,36 @@ async fn process_single_game(
 
         // Check if score has changed since last fetch to force refresh goal events
         let current_score = format!("{}-{}", game.home_team.goals, game.away_team.goals);
-        let score_changed = if let Some(cached_entry) = get_cached_goal_events_entry(game.season, game.id).await {
+        let score_changed = if let Some(cached_entry) =
+            get_cached_goal_events_entry(game.season, game.id).await
+        {
             // If we have cached events, check if the score has changed
             if cached_entry.was_cleared {
                 // Cache was intentionally cleared - use the last known score
                 if let Some(last_known_score) = &cached_entry.last_known_score {
-                    debug!("Comparing current score {} with last known score {} (from cleared cache)", current_score, last_known_score);
+                    debug!(
+                        "Comparing current score {} with last known score {} (from cleared cache)",
+                        current_score, last_known_score
+                    );
                     current_score != *last_known_score
                 } else {
                     // Cleared cache but no last known score - assume no change
-                    debug!("Cache was cleared but no last known score available, assuming no score change");
+                    debug!(
+                        "Cache was cleared but no last known score available, assuming no score change"
+                    );
                     false
                 }
             } else {
                 // Normal cache entry - check if the score has changed
                 if let Some(last_event) = cached_entry.data.last() {
-                    let cached_score = format!("{}-{}", last_event.home_team_score, last_event.away_team_score);
-                    debug!("Comparing current score {} with cached score {}", current_score, cached_score);
+                    let cached_score = format!(
+                        "{}-{}",
+                        last_event.home_team_score, last_event.away_team_score
+                    );
+                    debug!(
+                        "Comparing current score {} with cached score {}",
+                        current_score, cached_score
+                    );
                     current_score != cached_score
                 } else {
                     // No goal events in cache - this means cache was never populated

--- a/src/data_fetcher/api.rs
+++ b/src/data_fetcher/api.rs
@@ -446,12 +446,18 @@ async fn process_single_game(
             // For schedule response, we don't have detailed player data, so use fallback names
             for event in &game.home_team.goal_events {
                 if !event.goal_types.contains(&"RL0".to_string()) {
-                    player_names.insert(event.scorer_player_id, format!("Player {}", event.scorer_player_id));
+                    player_names.insert(
+                        event.scorer_player_id,
+                        format!("Player {}", event.scorer_player_id),
+                    );
                 }
             }
             for event in &game.away_team.goal_events {
                 if !event.goal_types.contains(&"RL0".to_string()) {
-                    player_names.insert(event.scorer_player_id, format!("Player {}", event.scorer_player_id));
+                    player_names.insert(
+                        event.scorer_player_id,
+                        format!("Player {}", event.scorer_player_id),
+                    );
                 }
             }
             crate::data_fetcher::processors::process_goal_events(&game, &player_names)

--- a/src/data_fetcher/cache.rs
+++ b/src/data_fetcher/cache.rs
@@ -959,7 +959,6 @@ pub async fn clear_goal_events_cache() {
 }
 
 /// Clears goal events cache for a specific game
-#[allow(dead_code)]
 pub async fn clear_goal_events_cache_for_game(season: i32, game_id: i32) {
     let key = create_goal_events_key(season, game_id);
     let mut cache = GOAL_EVENTS_CACHE.write().await;

--- a/src/data_fetcher/cache.rs
+++ b/src/data_fetcher/cache.rs
@@ -899,6 +899,15 @@ pub async fn clear_goal_events_cache() {
     GOAL_EVENTS_CACHE.write().await.clear();
 }
 
+/// Clears goal events cache for a specific game
+#[allow(dead_code)]
+pub async fn clear_goal_events_cache_for_game(season: i32, game_id: i32) {
+    let key = create_goal_events_key(season, game_id);
+    let mut cache = GOAL_EVENTS_CACHE.write().await;
+    cache.pop(&key);
+    debug!("Cleared goal events cache for game: season={}, game_id={}", season, game_id);
+}
+
 // HTTP Response Cache Functions
 
 /// Caches HTTP response data with TTL

--- a/src/data_fetcher/cache.rs
+++ b/src/data_fetcher/cache.rs
@@ -905,7 +905,10 @@ pub async fn clear_goal_events_cache_for_game(season: i32, game_id: i32) {
     let key = create_goal_events_key(season, game_id);
     let mut cache = GOAL_EVENTS_CACHE.write().await;
     cache.pop(&key);
-    debug!("Cleared goal events cache for game: season={}, game_id={}", season, game_id);
+    debug!(
+        "Cleared goal events cache for game: season={}, game_id={}",
+        season, game_id
+    );
 }
 
 // HTTP Response Cache Functions

--- a/src/data_fetcher/cache.rs
+++ b/src/data_fetcher/cache.rs
@@ -969,10 +969,12 @@ pub async fn clear_goal_events_cache_for_game(season: i32, game_id: i32) {
     // Get the current cached data to extract the last known score
     let last_known_score = if let Some(cached_entry) = cache.get(&key) {
         // Extract the last known score from the cached goal events
-        cached_entry.data.last().map(|last_event| format!(
-            "{}-{}",
-            last_event.home_team_score, last_event.away_team_score
-        ))
+        cached_entry.data.last().map(|last_event| {
+            format!(
+                "{}-{}",
+                last_event.home_team_score, last_event.away_team_score
+            )
+        })
     } else {
         None
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1431,7 +1431,12 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
                 },
                 Err(_) => {
                     // Timeout occurred during auto-refresh
-                    tracing::warn!("Auto-refresh timeout, continuing with existing data");
+                    tracing::warn!(
+                        "Auto-refresh timeout after {:?}, continuing with existing data ({} games, {} live games)",
+                        auto_refresh_interval,
+                        last_games.len(),
+                        last_games.iter().filter(|g| g.score_type == ScoreType::Ongoing).count()
+                    );
                     (Vec::new(), true, String::new(), true)
                 }
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1152,7 +1152,8 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
 
         // Debug logging for rate limit backoff enforcement
         if rate_limit_backoff > Duration::from_secs(0) {
-            let backoff_remaining = rate_limit_backoff.saturating_sub(last_rate_limit_hit.elapsed());
+            let backoff_remaining =
+                rate_limit_backoff.saturating_sub(last_rate_limit_hit.elapsed());
             if backoff_remaining > Duration::from_secs(0) {
                 tracing::debug!(
                     "Rate limit backoff active: {}s remaining (total backoff: {}s, elapsed since rate limit: {}s)",
@@ -1188,7 +1189,8 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
 
             // Log rate limit backoff status
             if rate_limit_backoff > Duration::from_secs(0) {
-                let backoff_remaining = rate_limit_backoff.saturating_sub(last_rate_limit_hit.elapsed());
+                let backoff_remaining =
+                    rate_limit_backoff.saturating_sub(last_rate_limit_hit.elapsed());
                 if backoff_remaining > Duration::from_secs(0) {
                     tracing::debug!(
                         "Auto-refresh skipped due to rate limit backoff: {}s remaining (total backoff: {}s)",
@@ -1465,7 +1467,10 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
                         "Auto-refresh timeout after {:?}, continuing with existing data ({} games, {} live games)",
                         auto_refresh_interval,
                         last_games.len(),
-                        last_games.iter().filter(|g| g.score_type == ScoreType::Ongoing).count()
+                        last_games
+                            .iter()
+                            .filter(|g| g.score_type == ScoreType::Ongoing)
+                            .count()
                     );
                     (Vec::new(), true, String::new(), true)
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,11 @@ struct Args {
     /// Specify a custom log file path. If not provided, logs will be written to the default location.
     #[arg(long = "log-file", help_heading = "Debug")]
     log_file: Option<String>,
+
+    /// Set minimum refresh interval in seconds (default: auto-detect based on game count).
+    /// Higher values reduce API calls but may miss updates. Use with caution.
+    #[arg(long = "min-refresh-interval", help_heading = "Display Options")]
+    min_refresh_interval: Option<u64>,
 }
 
 fn format_date_for_display(date_str: &str) -> String {
@@ -1106,6 +1111,10 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
     let mut cache_monitor_timer = Instant::now();
     const CACHE_MONITOR_INTERVAL: Duration = Duration::from_secs(300); // 5 minutes
 
+    // Rate limiting protection
+    let mut rate_limit_backoff = Duration::from_secs(0);
+    let mut last_rate_limit_hit = Instant::now().checked_sub(Duration::from_secs(60)).unwrap_or_else(Instant::now);
+
     loop {
         // Adaptive polling interval based on activity
         let time_since_activity = last_activity.elapsed();
@@ -1117,18 +1126,32 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
             Duration::from_millis(500) // Idle: 500ms (conserve CPU)
         };
 
-        // Check for auto-refresh with better logic
+        // Check for auto-refresh with better logic and rate limiting protection
         let auto_refresh_interval = if has_live_games_from_game_data(&last_games) {
-            Duration::from_secs(8) // Very frequent for live games (optimized for responsiveness)
+            Duration::from_secs(15) // Increased from 8 to 15 seconds for live games
         } else if last_games.iter().any(is_game_near_start_time) {
-            Duration::from_secs(10) // Very frequent for games near start time
+            Duration::from_secs(30) // Increased from 10 to 30 seconds for games near start time
         } else {
             Duration::from_secs(60) // Standard interval for completed/scheduled games
+        };
+
+        // Rate limiting protection: don't refresh too frequently if we have many games
+        let game_count = last_games.len();
+        let min_interval_between_refreshes = if let Some(user_interval) = args.min_refresh_interval {
+            Duration::from_secs(user_interval) // Use user-specified interval
+        } else if game_count >= 6 {
+            Duration::from_secs(30) // Minimum 30 seconds between refreshes for 6+ games
+        } else if game_count >= 4 {
+            Duration::from_secs(20) // Minimum 20 seconds between refreshes for 4-5 games
+        } else {
+            Duration::from_secs(10) // Minimum 10 seconds between refreshes for 1-3 games
         };
 
         if !needs_refresh
             && !last_games.is_empty()
             && last_auto_refresh.elapsed() >= auto_refresh_interval
+            && last_auto_refresh.elapsed() >= min_interval_between_refreshes
+            && last_rate_limit_hit.elapsed() >= rate_limit_backoff // Respect rate limit backoff
         {
             // Check if there are ongoing games - if so, always refresh
             let has_ongoing_games = has_live_games_from_game_data(&last_games);
@@ -1367,6 +1390,22 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
                                     message,
                                     url
                                 );
+                                
+                                // Implement exponential backoff for rate limits
+                                last_rate_limit_hit = Instant::now();
+                                if rate_limit_backoff.is_zero() {
+                                    rate_limit_backoff = Duration::from_secs(60); // Start with 1 minute
+                                } else {
+                                    // Double the backoff time, but cap at 10 minutes
+                                    rate_limit_backoff = std::cmp::min(
+                                        rate_limit_backoff * 2,
+                                        Duration::from_secs(600)
+                                    );
+                                }
+                                tracing::info!(
+                                    "Rate limit backoff set to {:?} seconds",
+                                    rate_limit_backoff.as_secs()
+                                );
                             }
                             _ => {
                                 tracing::warn!(
@@ -1388,22 +1427,27 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
                 },
                 Err(_) => {
                     // Timeout occurred during auto-refresh
-                    tracing::error!(
-                        "Auto-refresh timeout after {} seconds",
-                        timeout_duration.as_secs()
-                    );
-                    tracing::warn!(
-                        "Auto-refresh timed out, continuing with existing data and will retry on next cycle"
-                    );
-                    tracing::info!(
-                        "Continuing with existing data ({} games) due to auto-refresh timeout",
-                        last_games.len()
-                    );
-
-                    // Return empty games but indicate we should retry (don't update last_auto_refresh)
+                    tracing::warn!("Auto-refresh timeout, continuing with existing data");
                     (Vec::new(), true, String::new(), true)
                 }
             };
+
+            // Reset rate limit backoff on successful refresh
+            if !games.is_empty() && rate_limit_backoff > Duration::from_secs(0) {
+                // Gradually reduce backoff on successful requests
+                rate_limit_backoff = std::cmp::max(
+                    rate_limit_backoff / 2,
+                    Duration::from_secs(0)
+                );
+                if rate_limit_backoff.is_zero() {
+                    tracing::info!("Rate limit backoff reset to zero after successful request");
+                } else {
+                    tracing::debug!(
+                        "Rate limit backoff reduced to {:?} seconds after successful request",
+                        rate_limit_backoff.as_secs()
+                    );
+                }
+            }
 
             // Update current_date to track the actual date being displayed
             if !had_error && !fetched_date.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1113,7 +1113,9 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
 
     // Rate limiting protection
     let mut rate_limit_backoff = Duration::from_secs(0);
-    let mut last_rate_limit_hit = Instant::now().checked_sub(Duration::from_secs(60)).unwrap_or_else(Instant::now);
+    let mut last_rate_limit_hit = Instant::now()
+        .checked_sub(Duration::from_secs(60))
+        .unwrap_or_else(Instant::now);
 
     loop {
         // Adaptive polling interval based on activity
@@ -1137,7 +1139,8 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
 
         // Rate limiting protection: don't refresh too frequently if we have many games
         let game_count = last_games.len();
-        let min_interval_between_refreshes = if let Some(user_interval) = args.min_refresh_interval {
+        let min_interval_between_refreshes = if let Some(user_interval) = args.min_refresh_interval
+        {
             Duration::from_secs(user_interval) // Use user-specified interval
         } else if game_count >= 6 {
             Duration::from_secs(30) // Minimum 30 seconds between refreshes for 6+ games
@@ -1151,7 +1154,8 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
             && !last_games.is_empty()
             && last_auto_refresh.elapsed() >= auto_refresh_interval
             && last_auto_refresh.elapsed() >= min_interval_between_refreshes
-            && last_rate_limit_hit.elapsed() >= rate_limit_backoff // Respect rate limit backoff
+            && last_rate_limit_hit.elapsed() >= rate_limit_backoff
+        // Respect rate limit backoff
         {
             // Check if there are ongoing games - if so, always refresh
             let has_ongoing_games = has_live_games_from_game_data(&last_games);
@@ -1390,7 +1394,7 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
                                     message,
                                     url
                                 );
-                                
+
                                 // Implement exponential backoff for rate limits
                                 last_rate_limit_hit = Instant::now();
                                 if rate_limit_backoff.is_zero() {
@@ -1399,7 +1403,7 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
                                     // Double the backoff time, but cap at 10 minutes
                                     rate_limit_backoff = std::cmp::min(
                                         rate_limit_backoff * 2,
-                                        Duration::from_secs(600)
+                                        Duration::from_secs(600),
                                     );
                                 }
                                 tracing::info!(
@@ -1435,10 +1439,7 @@ async fn run_interactive_ui(stdout: &mut std::io::Stdout, args: &Args) -> Result
             // Reset rate limit backoff on successful refresh
             if !games.is_empty() && rate_limit_backoff > Duration::from_secs(0) {
                 // Gradually reduce backoff on successful requests
-                rate_limit_backoff = std::cmp::max(
-                    rate_limit_backoff / 2,
-                    Duration::from_secs(0)
-                );
+                rate_limit_backoff = std::cmp::max(rate_limit_backoff / 2, Duration::from_secs(0));
                 if rate_limit_backoff.is_zero() {
                     tracing::info!("Rate limit backoff reset to zero after successful request");
                 } else {


### PR DESCRIPTION
- Add exponential backoff for API rate limit (429) errors
- Implement adaptive refresh intervals based on game count
- Add --min-refresh-interval CLI option for manual control
- Increase default cache TTLs to reduce API calls
- Update README with new features and CLI options
- Improve API-friendly behavior for full game rounds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to set a minimum refresh interval for updates.
  * Implemented adaptive refresh intervals with exponential backoff to protect against API rate limiting.
  * Users can now configure the minimum interval between refreshes.

* **Improvements**
  * Increased default refresh intervals for live and starting games to reduce API calls.
  * Enhanced error handling for rate limiting with clearer warnings and smarter retry logic.
  * Added fallback processing of goal events from schedule data when detailed game data is unavailable.
  * Improved cache management to clear outdated goal event data upon score changes.

* **Documentation**
  * Updated the README to document new refresh interval options and rate limiting protection features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->