### PR TITLE
Fix/replace-lazy-static-with-lazy-lock

### DIFF
--- a/.idea/liiga_teletext.iml
+++ b/.idea/liiga_teletext.iml
@@ -3,6 +3,7 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,28 +108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,7 +973,6 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures",
- "lazy_static",
  "lru",
  "reqwest",
  "semver",
@@ -1005,7 +982,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
- "tokio-test",
  "toml",
  "tracing",
  "tracing-appender",
@@ -1924,30 +1900,6 @@ checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
-dependencies = [
- "async-stream",
- "bytes",
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 repository = "https://github.com/nikosalonen/liiga_teletext"
 homepage = "https://github.com/nikosalonen/liiga_teletext"
 documentation = "https://github.com/nikosalonen/liiga_teletext#readme"
+rust-version = "1.85"
 include = [
     "src/**/*",
     "Cargo.toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1.0"
 toml = "0.9.2"
 dirs = "6.0.0"
 futures = "0.3"
-lazy_static = "1.5.0"
+
 clap = { version = "4.5.41", features = ["derive"] }
 semver = "1.0.22"
 thiserror = "2.0.12"
@@ -45,6 +45,5 @@ lru = "0.16.0"
 [dev-dependencies]
 tempfile = "3.10"
 wiremock = "0.6"
-tokio-test = "0.4"
 serial_test = "3.2.0"
 unicode-width = "0.2.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -669,7 +669,7 @@ another_extra = 123
         assert!(config_path.ends_with("config.toml"));
 
         // Verify it's a valid path (doesn't test if it exists, just that it's a valid path format)
-        let path = std::path::Path::new(&config_path);
+        let path = Path::new(&config_path);
         assert!(path.is_absolute() || path.is_relative());
     }
 
@@ -682,7 +682,7 @@ another_extra = 123
         assert!(log_dir_path.ends_with("logs"));
 
         // Verify it's a valid path
-        let path = std::path::Path::new(&log_dir_path);
+        let path = Path::new(&log_dir_path);
         assert!(path.is_absolute() || path.is_relative());
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -218,7 +218,7 @@ mod tests {
         let min_time = validation::MIN_GAME_TIME_MINUTES;
         let max_score = validation::MAX_TEAM_SCORE;
         let max_team_name = validation::MAX_TEAM_NAME_LENGTH;
-        let max_player_name = validation::MAX_PLAYER_NAME_LENGTH;
+        let max_player_name = MAX_PLAYER_NAME_LENGTH;
 
         assert!(max_time > min_time);
         assert!(max_score > 0);

--- a/src/data_fetcher/api.rs
+++ b/src/data_fetcher/api.rs
@@ -633,7 +633,7 @@ async fn fetch<T: DeserializeOwned>(client: &Client, url: &str) -> Result<T, App
             } else {
                 // For other reqwest errors, keep the original behavior
                 Err(AppError::ApiFetch(e))
-            }
+            };
         }
     };
 
@@ -1149,11 +1149,9 @@ async fn fetch_game_data(
 
             // Transform API not found errors to game-specific errors
             return match &e {
-                AppError::ApiNotFound { .. } => {
-                    Err(AppError::api_game_not_found(game_id, season))
-                }
+                AppError::ApiNotFound { .. } => Err(AppError::api_game_not_found(game_id, season)),
                 _ => Err(e),
-            }
+            };
         }
     };
 

--- a/src/data_fetcher/api.rs
+++ b/src/data_fetcher/api.rs
@@ -47,7 +47,7 @@ const PLAYOFFS_END_MONTH: u32 = 6; // June
 /// * HTTP/2 multiplexing when available
 /// * Automatic retry logic for transient failures
 fn create_http_client() -> Client {
-    reqwest::Client::builder()
+    Client::builder()
         .timeout(Duration::from_secs(30))
         .pool_max_idle_per_host(100)
         .build()
@@ -512,7 +512,7 @@ async fn process_single_game(
                     );
                 }
             }
-            crate::data_fetcher::processors::process_goal_events(&game, &player_names)
+            process_goal_events(&game, &player_names)
         } else {
             info!("No detailed data needed for this game");
             Vec::new()
@@ -626,13 +626,13 @@ async fn fetch<T: DeserializeOwned>(client: &Client, url: &str) -> Result<T, App
             error!("Request failed for URL {}: {}", url, e);
 
             // Categorize reqwest errors into specific types
-            if e.is_timeout() {
-                return Err(AppError::network_timeout(url));
+            return if e.is_timeout() {
+                Err(AppError::network_timeout(url))
             } else if e.is_connect() {
-                return Err(AppError::network_connection(url, e.to_string()));
+                Err(AppError::network_connection(url, e.to_string()))
             } else {
                 // For other reqwest errors, keep the original behavior
-                return Err(AppError::ApiFetch(e));
+                Err(AppError::ApiFetch(e))
             }
         }
     };
@@ -1148,11 +1148,11 @@ async fn fetch_game_data(
             );
 
             // Transform API not found errors to game-specific errors
-            match &e {
+            return match &e {
                 AppError::ApiNotFound { .. } => {
-                    return Err(AppError::api_game_not_found(game_id, season));
+                    Err(AppError::api_game_not_found(game_id, season))
                 }
-                _ => return Err(e),
+                _ => Err(e),
             }
         }
     };
@@ -2018,17 +2018,17 @@ async fn process_goal_events_for_historical_game_with_players(
     let mut all_goal_events = Vec::new();
 
     // Create player lookup maps for efficient name resolution
-    let home_player_map: std::collections::HashMap<i64, &Player> = home_team_players
+    let home_player_map: HashMap<i64, &Player> = home_team_players
         .iter()
         .map(|player| (player.id, player))
         .collect();
-    let away_player_map: std::collections::HashMap<i64, &Player> = away_team_players
+    let away_player_map: HashMap<i64, &Player> = away_team_players
         .iter()
         .map(|player| (player.id, player))
         .collect();
 
     // Helper function to get player name with fallback
-    let get_player_name = |player_id: i64, player_map: &std::collections::HashMap<i64, &Player>| {
+    let get_player_name = |player_id: i64, player_map: &HashMap<i64, &Player>| {
         player_map
             .get(&player_id)
             .map(|player| format!("{} {}", player.first_name, player.last_name))
@@ -2513,7 +2513,7 @@ mod tests {
         clear_all_caches().await;
 
         // Wait for cache clearing to complete
-        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
 
         // Verify cache is actually empty - check all cache types
         let initial_player_cache_size = get_cache_size().await;

--- a/src/data_fetcher/cache.rs
+++ b/src/data_fetcher/cache.rs
@@ -549,15 +549,14 @@ pub async fn get_cached_tournament_data_with_start_check(
 
     if let Some(cached_entry) = cache.get(key) {
         // Check if we have any games that might be starting
-        let has_starting_games = current_games.iter().any(|game| {
-            game.score_type == ScoreType::Scheduled && !game.start.is_empty()
-        });
+        let has_starting_games = current_games
+            .iter()
+            .any(|game| game.score_type == ScoreType::Scheduled && !game.start.is_empty());
 
         // If we have starting games, consider cache expired more aggressively
         if has_starting_games {
             let age = cached_entry.cached_at.elapsed();
-            let aggressive_ttl =
-                Duration::from_secs(cache_ttl::STARTING_GAMES_SECONDS); // 10 seconds for starting games
+            let aggressive_ttl = Duration::from_secs(cache_ttl::STARTING_GAMES_SECONDS); // 10 seconds for starting games
 
             if age > aggressive_ttl {
                 info!(

--- a/src/data_fetcher/player_names.rs
+++ b/src/data_fetcher/player_names.rs
@@ -316,8 +316,7 @@ fn apply_progressive_disambiguation_by_indices(
             );
 
             // Check if extended disambiguation actually creates unique identifiers
-            let mut unique_names: HashSet<String> =
-                HashSet::new();
+            let mut unique_names: HashSet<String> = HashSet::new();
             let mut all_unique = true;
 
             for (_, name) in &extended_disambiguated {

--- a/src/data_fetcher/player_names.rs
+++ b/src/data_fetcher/player_names.rs
@@ -316,8 +316,8 @@ fn apply_progressive_disambiguation_by_indices(
             );
 
             // Check if extended disambiguation actually creates unique identifiers
-            let mut unique_names: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
+            let mut unique_names: HashSet<String> =
+                HashSet::new();
             let mut all_unique = true;
 
             for (_, name) in &extended_disambiguated {

--- a/src/data_fetcher/processors.rs
+++ b/src/data_fetcher/processors.rs
@@ -359,7 +359,7 @@ pub fn format_time(timestamp: &str) -> Result<String, AppError> {
 /// Checks if a game has recent events indicating it's actually live
 /// even if the started field hasn't been updated yet
 fn has_recent_events(game: &ScheduleGame) -> bool {
-    let now = chrono::Utc::now();
+    let now = Utc::now();
     let recent_threshold = chrono::Duration::minutes(5); // Events within 5 minutes
 
     // Check for recent goal events from both teams
@@ -368,7 +368,7 @@ fn has_recent_events(game: &ScheduleGame) -> bool {
         .flat_map(|events| events.iter())
         .any(|event| {
             if let Ok(event_time) = chrono::DateTime::parse_from_rfc3339(&event.log_time) {
-                let time_diff = now.signed_duration_since(event_time.with_timezone(&chrono::Utc));
+                let time_diff = now.signed_duration_since(event_time.with_timezone(&Utc));
                 time_diff >= chrono::Duration::zero() && time_diff <= recent_threshold
             } else {
                 false
@@ -385,10 +385,10 @@ fn has_recent_events(game: &ScheduleGame) -> bool {
 
 /// Determines if a game with game_time > 0 is likely actually live
 fn is_game_likely_live(game: &ScheduleGame) -> bool {
-    let now = chrono::Utc::now();
+    let now = Utc::now();
 
     if let Ok(game_start) = chrono::DateTime::parse_from_rfc3339(&game.start) {
-        let time_since_start = now.signed_duration_since(game_start.with_timezone(&chrono::Utc));
+        let time_since_start = now.signed_duration_since(game_start.with_timezone(&Utc));
 
         // Only consider it live if:
         // 1. Game was supposed to start within the last 3 hours (not old data)

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,7 +361,7 @@ async fn main() -> Result<(), AppError> {
             registry
                 .with(
                     fmt::Layer::new()
-                        .with_writer(std::io::stdout)
+                        .with_writer(stdout)
                         .with_ansi(true)
                         .with_filter(
                             EnvFilter::from_default_env()

--- a/src/teletext_ui.rs
+++ b/src/teletext_ui.rs
@@ -670,10 +670,10 @@ impl TeletextPage {
     /// # Errors
     /// Returns an error if both compact_mode and wide_mode are enabled in the configuration.
     #[allow(dead_code)] // Used in tests
-    pub fn from_config(config: TeletextPageConfig) -> Result<Self, crate::AppError> {
+    pub fn from_config(config: TeletextPageConfig) -> Result<Self, AppError> {
         // Validate mode exclusivity before creating the page
         if let Err(msg) = config.validate_mode_exclusivity() {
-            return Err(crate::AppError::config_error(format!(
+            return Err(AppError::config_error(format!(
                 "Invalid TeletextPageConfig: {msg}"
             )));
         }
@@ -2953,7 +2953,7 @@ mod tests {
                 },
             ];
 
-            page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+            page.add_game_result(GameResultData::new(&GameData {
                 home_team: format!("Home {i}"),
                 away_team: format!("Away {i}"),
                 time: "18.00".to_string(),
@@ -3020,7 +3020,7 @@ mod tests {
                 },
             ];
 
-            page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+            page.add_game_result(GameResultData::new(&GameData {
                 home_team: format!("Home {i}"),
                 away_team: format!("Away {i}"),
                 time: "18.00".to_string(),
@@ -3067,7 +3067,7 @@ mod tests {
         );
 
         // Test game without goals
-        page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+        page.add_game_result(GameResultData::new(&GameData {
             home_team: "Home".to_string(),
             away_team: "Away".to_string(),
             time: "18.00".to_string(),
@@ -3094,7 +3094,7 @@ mod tests {
             video_clip_url: None,
         }];
 
-        page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+        page.add_game_result(GameResultData::new(&GameData {
             home_team: "Home".to_string(),
             away_team: "Away".to_string(),
             time: "18.00".to_string(),
@@ -3149,7 +3149,7 @@ mod tests {
         );
 
         // Test scheduled game display
-        page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+        page.add_game_result(GameResultData::new(&GameData {
             home_team: "Home".to_string(),
             away_team: "Away".to_string(),
             time: "18.00".to_string(),
@@ -3189,7 +3189,7 @@ mod tests {
             },
         ];
 
-        page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+        page.add_game_result(GameResultData::new(&GameData {
             home_team: "Home".to_string(),
             away_team: "Away".to_string(),
             time: "".to_string(),
@@ -3204,7 +3204,7 @@ mod tests {
         }));
 
         // Test finished game with overtime
-        page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+        page.add_game_result(GameResultData::new(&GameData {
             home_team: "Home OT".to_string(),
             away_team: "Away OT".to_string(),
             time: "".to_string(),
@@ -3219,7 +3219,7 @@ mod tests {
         }));
 
         // Test finished game with shootout
-        page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+        page.add_game_result(GameResultData::new(&GameData {
             home_team: "Home SO".to_string(),
             away_team: "Away SO".to_string(),
             time: "".to_string(),
@@ -3295,7 +3295,7 @@ mod tests {
             video_clip_url: Some("http://example.com".to_string()),
         }];
 
-        page.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+        page.add_game_result(GameResultData::new(&GameData {
             home_team: "Home".to_string(),
             away_team: "Away".to_string(),
             time: "".to_string(),
@@ -3321,7 +3321,7 @@ mod tests {
             false,
         );
 
-        page_no_video.add_game_result(GameResultData::new(&crate::data_fetcher::GameData {
+        page_no_video.add_game_result(GameResultData::new(&GameData {
             home_team: "Home".to_string(),
             away_team: "Away".to_string(),
             time: "".to_string(),
@@ -4199,7 +4199,7 @@ mod tests {
         );
 
         // Add some test games using GameData -> GameResultData
-        let test_game = crate::data_fetcher::GameData {
+        let test_game = GameData {
             home_team: "HIFK".to_string(),
             away_team: "Tappara".to_string(),
             time: "18:30".to_string(),
@@ -4236,7 +4236,7 @@ mod tests {
         );
 
         // Add some test games
-        let test_game = crate::data_fetcher::GameData {
+        let test_game = GameData {
             home_team: "HIFK".to_string(),
             away_team: "Tappara".to_string(),
             time: "18:30".to_string(),
@@ -4274,7 +4274,7 @@ mod tests {
 
         // Add multiple test games to test distribution
         for i in 0..4 {
-            let test_game = crate::data_fetcher::GameData {
+            let test_game = GameData {
                 home_team: format!("Team{i}A"),
                 away_team: format!("Team{i}B"),
                 time: "18:30".to_string(),
@@ -4318,7 +4318,7 @@ mod tests {
 
         // Add 3 test games (odd number)
         for i in 0..3 {
-            let test_game = crate::data_fetcher::GameData {
+            let test_game = GameData {
                 home_team: format!("Team{i}A"),
                 away_team: format!("Team{i}B"),
                 time: "18:30".to_string(),
@@ -4362,7 +4362,7 @@ mod tests {
         );
 
         // Add test games
-        let test_game1 = crate::data_fetcher::GameData {
+        let test_game1 = GameData {
             home_team: "HIFK".to_string(),
             away_team: "Tappara".to_string(),
             time: "18:30".to_string(),
@@ -4376,7 +4376,7 @@ mod tests {
             start: "2024-01-15T18:30:00Z".to_string(),
         };
 
-        let test_game2 = crate::data_fetcher::GameData {
+        let test_game2 = GameData {
             home_team: "TPS".to_string(),
             away_team: "KalPa".to_string(),
             time: "19:00".to_string(),
@@ -4397,10 +4397,7 @@ mod tests {
         let (left_games, right_games) = page.distribute_games_for_wide_display();
 
         // Should have games distributed (exact distribution depends on content size)
-        assert!(
-            left_games.len() + right_games.len() == 2,
-            "Should have both games distributed"
-        );
+        assert_eq!(left_games.len() + right_games.len(), 2, "Should have both games distributed");
         assert!(
             !left_games.is_empty(),
             "Should have at least one game in left column"
@@ -4548,7 +4545,7 @@ mod tests {
         assert!(result.is_err());
 
         let error = result.unwrap_err();
-        assert!(matches!(error, crate::AppError::Config(_)));
+        assert!(matches!(error, AppError::Config(_)));
         assert!(
             error
                 .to_string()

--- a/src/teletext_ui.rs
+++ b/src/teletext_ui.rs
@@ -4397,7 +4397,11 @@ mod tests {
         let (left_games, right_games) = page.distribute_games_for_wide_display();
 
         // Should have games distributed (exact distribution depends on content size)
-        assert_eq!(left_games.len() + right_games.len(), 2, "Should have both games distributed");
+        assert_eq!(
+            left_games.len() + right_games.len(),
+            2,
+            "Should have both games distributed"
+        );
         assert!(
             !left_games.is_empty(),
             "Should have at least one game in left column"

--- a/tests/disambiguation_display_tests.rs
+++ b/tests/disambiguation_display_tests.rs
@@ -853,7 +853,7 @@ fn test_disambiguation_error_scenarios_in_display() {
         ("wide", false, true),
     ];
 
-    for (mode_name, compact, wide) in modes {
+    for (_mode_name, compact, wide) in modes {
         let mut page = create_test_page(compact, wide);
 
         page.add_game_result(error_game.clone());
@@ -863,30 +863,30 @@ fn test_disambiguation_error_scenarios_in_display() {
         assert_eq!(
             page.total_pages(),
             1,
-            "{mode_name} mode should handle error data gracefully"
+            "{_mode_name} mode should handle error data gracefully"
         );
 
         if compact {
             assert!(
                 page.is_compact_mode(),
-                "{mode_name} mode should maintain correct compact setting"
+                "{_mode_name} mode should maintain correct compact setting"
             );
         } else {
             assert!(
                 !page.is_compact_mode(),
-                "{mode_name} mode should maintain correct compact setting"
+                "{_mode_name} mode should maintain correct compact setting"
             );
         }
 
         if wide {
             assert!(
                 page.is_wide_mode(),
-                "{mode_name} mode should maintain correct wide setting"
+                "{_mode_name} mode should maintain correct wide setting"
             );
         } else {
             assert!(
                 !page.is_wide_mode(),
-                "{mode_name} mode should maintain correct wide setting"
+                "{_mode_name} mode should maintain correct wide setting"
             );
         }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -152,10 +152,7 @@ async fn test_game_result_data_creation() {
     assert_eq!(game_result.away_team, "Tappara");
     assert_eq!(game_result.time, "18:30");
     assert_eq!(game_result.result, "3-2");
-    assert!(matches!(
-        game_result.score_type,
-        ScoreType::Final
-    ));
+    assert!(matches!(game_result.score_type, ScoreType::Final));
     assert!(game_result.is_overtime);
     assert!(!game_result.is_shootout);
 }
@@ -343,10 +340,7 @@ async fn test_ongoing_games() {
     // Verify game data
     assert_eq!(ongoing_game.result, "2-1");
     assert_eq!(ongoing_game.time, "18:30");
-    assert!(matches!(
-        ongoing_game.score_type,
-        ScoreType::Ongoing
-    ));
+    assert!(matches!(ongoing_game.score_type, ScoreType::Ongoing));
 }
 
 /// Test games with special situations (overtime, shootout)
@@ -1075,7 +1069,11 @@ async fn test_wide_mode_game_distribution_integration() {
 
     // Verify games are distributed
     assert!(!left_games.is_empty(), "Left column should have games");
-    assert_eq!(left_games.len() + right_games.len(), teams.len(), "All games should be distributed between columns");
+    assert_eq!(
+        left_games.len() + right_games.len(),
+        teams.len(),
+        "All games should be distributed between columns"
+    );
 
     // Left column should typically have equal or one more game than right
     // (left-column-first distribution)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -82,7 +82,7 @@ async fn test_page_navigation() {
             away_team: format!("Team {}", i * 2 + 1),
             time: "18:30".to_string(),
             result: "1-0".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+            score_type: ScoreType::Final,
             is_overtime: false,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -135,7 +135,7 @@ async fn test_game_result_data_creation() {
         away_team: "Tappara".to_string(),
         time: "18:30".to_string(),
         result: "3-2".to_string(),
-        score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+        score_type: ScoreType::Final,
         is_overtime: true,
         is_shootout: false,
         serie: "runkosarja".to_string(),
@@ -154,7 +154,7 @@ async fn test_game_result_data_creation() {
     assert_eq!(game_result.result, "3-2");
     assert!(matches!(
         game_result.score_type,
-        liiga_teletext::teletext_ui::ScoreType::Final
+        ScoreType::Final
     ));
     assert!(game_result.is_overtime);
     assert!(!game_result.is_shootout);
@@ -169,7 +169,7 @@ async fn test_teletext_ui_generation() {
         away_team: "Tappara".to_string(),
         time: "18:30".to_string(),
         result: "3-2".to_string(),
-        score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+        score_type: ScoreType::Final,
         is_overtime: false,
         is_shootout: false,
         serie: "runkosarja".to_string(),
@@ -239,7 +239,7 @@ async fn test_end_to_end_multiple_games() {
             away_team: "Tappara".to_string(),
             time: "18:30".to_string(),
             result: "3-2".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+            score_type: ScoreType::Final,
             is_overtime: false,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -252,7 +252,7 @@ async fn test_end_to_end_multiple_games() {
             away_team: "Lukko".to_string(),
             time: "19:00".to_string(),
             result: "1-4".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+            score_type: ScoreType::Final,
             is_overtime: false,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -293,7 +293,7 @@ async fn test_different_tournament_types() {
         away_team: "Tappara".to_string(),
         time: "18:30".to_string(),
         result: "2-1".to_string(),
-        score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+        score_type: ScoreType::Final,
         is_overtime: false,
         is_shootout: false,
         serie: "playoffs".to_string(),
@@ -331,7 +331,7 @@ async fn test_ongoing_games() {
         away_team: "Tappara".to_string(),
         time: "18:30".to_string(),
         result: "2-1".to_string(),
-        score_type: liiga_teletext::teletext_ui::ScoreType::Ongoing,
+        score_type: ScoreType::Ongoing,
         is_overtime: false,
         is_shootout: false,
         serie: "runkosarja".to_string(),
@@ -345,7 +345,7 @@ async fn test_ongoing_games() {
     assert_eq!(ongoing_game.time, "18:30");
     assert!(matches!(
         ongoing_game.score_type,
-        liiga_teletext::teletext_ui::ScoreType::Ongoing
+        ScoreType::Ongoing
     ));
 }
 
@@ -358,7 +358,7 @@ async fn test_special_situations() {
         away_team: "Tappara".to_string(),
         time: "18:30".to_string(),
         result: "3-2".to_string(),
-        score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+        score_type: ScoreType::Final,
         is_overtime: true,
         is_shootout: false,
         serie: "runkosarja".to_string(),
@@ -382,7 +382,7 @@ async fn test_compact_mode_non_interactive() {
             away_team: "Tappara".to_string(),
             time: "18:30".to_string(),
             result: "3-2".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+            score_type: ScoreType::Final,
             is_overtime: true,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -395,7 +395,7 @@ async fn test_compact_mode_non_interactive() {
             away_team: "Lukko".to_string(),
             time: "19:00".to_string(),
             result: "1-4".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+            score_type: ScoreType::Final,
             is_overtime: false,
             is_shootout: true,
             serie: "runkosarja".to_string(),
@@ -408,7 +408,7 @@ async fn test_compact_mode_non_interactive() {
             away_team: "JYP".to_string(),
             time: "19:30".to_string(),
             result: "".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Scheduled,
+            score_type: ScoreType::Scheduled,
             is_overtime: false,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -466,7 +466,7 @@ async fn test_compact_mode_with_dates() {
         away_team: "Tappara".to_string(),
         time: "18:30".to_string(),
         result: "3-2".to_string(),
-        score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+        score_type: ScoreType::Final,
         is_overtime: false,
         is_shootout: false,
         serie: "runkosarja".to_string(),
@@ -480,7 +480,7 @@ async fn test_compact_mode_with_dates() {
         away_team: "Lukko".to_string(),
         time: "19:00".to_string(),
         result: "".to_string(),
-        score_type: liiga_teletext::teletext_ui::ScoreType::Scheduled,
+        score_type: ScoreType::Scheduled,
         is_overtime: false,
         is_shootout: false,
         serie: "runkosarja".to_string(),
@@ -602,7 +602,7 @@ async fn test_compact_mode_preserves_styling() {
             away_team: "Tappara".to_string(),
             time: "18:30".to_string(),
             result: "3-2".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+            score_type: ScoreType::Final,
             is_overtime: true,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -615,7 +615,7 @@ async fn test_compact_mode_preserves_styling() {
             away_team: "Lukko".to_string(),
             time: "19:00".to_string(),
             result: "1-0".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Ongoing,
+            score_type: ScoreType::Ongoing,
             is_overtime: false,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -628,7 +628,7 @@ async fn test_compact_mode_preserves_styling() {
             away_team: "JYP".to_string(),
             time: "19:30".to_string(),
             result: "".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Scheduled,
+            score_type: ScoreType::Scheduled,
             is_overtime: false,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -759,7 +759,7 @@ async fn test_compact_mode_basic_functionality() {
             away_team: "HIFK".to_string(),
             time: "18:30".to_string(),
             result: "3-2".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Final,
+            score_type: ScoreType::Final,
             is_overtime: true,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -772,7 +772,7 @@ async fn test_compact_mode_basic_functionality() {
             away_team: "Lukko".to_string(),
             time: "19:00".to_string(),
             result: "".to_string(),
-            score_type: liiga_teletext::teletext_ui::ScoreType::Scheduled,
+            score_type: ScoreType::Scheduled,
             is_overtime: false,
             is_shootout: false,
             serie: "runkosarja".to_string(),
@@ -1075,10 +1075,7 @@ async fn test_wide_mode_game_distribution_integration() {
 
     // Verify games are distributed
     assert!(!left_games.is_empty(), "Left column should have games");
-    assert!(
-        left_games.len() + right_games.len() == teams.len(),
-        "All games should be distributed between columns"
-    );
+    assert_eq!(left_games.len() + right_games.len(), teams.len(), "All games should be distributed between columns");
 
     // Left column should typically have equal or one more game than right
     // (left-column-first distribution)


### PR DESCRIPTION
- Adjusted assertion formatting in multiple test cases to enhance readability by aligning parameters and using consistent formatting.
- This change aims to improve the clarity of test assertions, making it easier to understand the expected outcomes and maintain the test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified import paths and removed redundant module prefixes across multiple files for improved code readability.
  * Replaced static cache initialization with Rust's standard library synchronization primitive for better maintainability.
  * Updated logging output handling for non-interactive modes.
  * Minor improvements to test code for clarity.

* **Chores**
  * Updated dependencies: removed `lazy_static`, added `clap` with derive feature, and removed `tokio-test`.
  * Updated module configuration to explicitly mark the "tests" directory as a test source root.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->