### PR TITLE
refactor: enhance date fetching logic and improve game detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "liiga_teletext"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,9 +1698,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liiga_teletext"
-version = "0.15.3"
+version = "0.15.4"
 edition = "2024"
 authors = ["Niko Salonen <nikotsalonen@gmail.com>"]
 description = "YLE Teksti-TV 221 in your terminal - Finnish Liiga hockey results with authentic teletext aesthetics"

--- a/src/data_fetcher/api.rs
+++ b/src/data_fetcher/api.rs
@@ -17,7 +17,7 @@ use crate::data_fetcher::models::{
 use crate::data_fetcher::player_names::format_for_display;
 use crate::data_fetcher::processors::{
     create_basic_goal_events, determine_game_status, format_time, process_goal_events,
-    should_show_todays_games,
+    should_show_todays_games_with_time,
 };
 use crate::error::AppError;
 use crate::teletext_ui::ScoreType;
@@ -184,7 +184,7 @@ fn determine_fetch_date(custom_date: Option<String>) -> (String, bool) {
             // Convert to local time for the date decision logic
             let now_local = now_utc.with_timezone(&Local);
 
-            if should_show_todays_games() {
+            if should_show_todays_games_with_time(now_local) {
                 let date_str = now_local.format("%Y-%m-%d").to_string();
                 info!("Using today's date: {}", date_str);
                 (date_str, false)

--- a/src/data_fetcher/processors.rs
+++ b/src/data_fetcher/processors.rs
@@ -665,15 +665,25 @@ mod tests {
         use chrono::{Local, NaiveTime, TimeZone};
         let today = Local::now();
 
-        let morning_naive = today.date_naive().and_time(NaiveTime::from_hms_opt(11, 59, 59).unwrap());
-        let morning_dt = chrono::Local.from_local_datetime(&morning_naive).single().unwrap();
+        let morning_naive = today
+            .date_naive()
+            .and_time(NaiveTime::from_hms_opt(11, 59, 59).unwrap());
+        let morning_dt = chrono::Local
+            .from_local_datetime(&morning_naive)
+            .single()
+            .unwrap();
         assert!(
             !should_show_todays_games_with_time(morning_dt),
             "Before noon should show yesterday's games"
         );
 
-        let noon_naive = today.date_naive().and_time(NaiveTime::from_hms_opt(12, 0, 0).unwrap());
-        let noon_dt = chrono::Local.from_local_datetime(&noon_naive).single().unwrap();
+        let noon_naive = today
+            .date_naive()
+            .and_time(NaiveTime::from_hms_opt(12, 0, 0).unwrap());
+        let noon_dt = chrono::Local
+            .from_local_datetime(&noon_naive)
+            .single()
+            .unwrap();
         assert!(
             should_show_todays_games_with_time(noon_dt),
             "At/after noon should show today's games"

--- a/src/data_fetcher/processors.rs
+++ b/src/data_fetcher/processors.rs
@@ -661,19 +661,31 @@ mod tests {
     }
 
     #[test]
-    fn test_should_show_todays_games() {
-        // This function depends on current time, so we test the logic indirectly
-        // by checking that it returns a boolean
-        let result = should_show_todays_games();
-        // Just verify it returns a boolean value (no assertion needed)
-        let _: bool = result;
+    fn test_should_show_todays_games_deterministic_examples() {
+        use chrono::{Local, NaiveTime, TimeZone};
+        let today = Local::now();
+
+        let morning_naive = today.date_naive().and_time(NaiveTime::from_hms_opt(11, 59, 59).unwrap());
+        let morning_dt = chrono::Local.from_local_datetime(&morning_naive).single().unwrap();
+        assert!(
+            !should_show_todays_games_with_time(morning_dt),
+            "Before noon should show yesterday's games"
+        );
+
+        let noon_naive = today.date_naive().and_time(NaiveTime::from_hms_opt(12, 0, 0).unwrap());
+        let noon_dt = chrono::Local.from_local_datetime(&noon_naive).single().unwrap();
+        assert!(
+            should_show_todays_games_with_time(noon_dt),
+            "At/after noon should show today's games"
+        );
     }
 
     #[test]
     fn test_should_show_todays_games_consistency() {
-        // Multiple calls should return the same result within a short time frame
-        let result1 = should_show_todays_games();
-        let result2 = should_show_todays_games();
+        // Multiple evaluations against the same captured time must be equal
+        let now_local = chrono::Local::now();
+        let result1 = should_show_todays_games_with_time(now_local);
+        let result2 = should_show_todays_games_with_time(now_local);
         assert_eq!(result1, result2);
     }
 

--- a/src/ui/interactive.rs
+++ b/src/ui/interactive.rs
@@ -1978,7 +1978,10 @@ mod tests {
 
         // Test games later today should NOT be considered future games for "Seuraavat ottelut"
         let now = chrono::Local::now();
-        let today_later = now.date_naive().and_hms_opt(23, 59, 59).unwrap()
+        let today_later = now
+            .date_naive()
+            .and_hms_opt(23, 59, 59)
+            .unwrap()
             .and_local_timezone(chrono::Local::now().timezone())
             .single()
             .unwrap()
@@ -2002,8 +2005,10 @@ mod tests {
         assert!(!is_future_game(&game_later_today));
 
         // Test games tomorrow should be considered future games
-        let tomorrow = (now + chrono::Duration::days(1)).date_naive()
-            .and_hms_opt(18, 30, 0).unwrap()
+        let tomorrow = (now + chrono::Duration::days(1))
+            .date_naive()
+            .and_hms_opt(18, 30, 0)
+            .unwrap()
             .and_local_timezone(chrono::Local::now().timezone())
             .single()
             .unwrap()


### PR DESCRIPTION
- Updated `determine_fetch_date` to return a tuple indicating whether the date was chosen due to morning cutoff logic, improving clarity in date handling.
- Modified `handle_no_games_found` to log specific messages based on whether the date was affected by the morning cutoff, enhancing user experience during game searches.
- Adjusted the cutoff time for showing today's games to a consistent noon (12:00) across all seasons, ensuring uniform behavior year-round.
- Added unit tests to verify the new noon cutoff behavior, ensuring accurate game visibility logic.

These changes improve the accuracy and clarity of date handling in the application, enhancing the overall user experience.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Time-aware date resolution with deterministic time injection for testing; fetch logic now conveys pre-noon cutoff context.

- **Bug Fixes**
  - Standardized to a year-round local-noon cutoff for showing today’s games; improved early-day handling and date fallback based on cutoff context.
  - No-games handling and logging now distinguish pre-noon cutoff vs standard flow.

- **Tests**
  - Added deterministic time-aware tests for cutoff logic, date selection, and edge cases.

- **Style**
  - Minor test formatting updates.

- **Chores**
  - Project version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->