### PR TITLE
fix(ui): recover auto-refresh when games list empty; preserve state on fetch error

### DIFF
--- a/src/ui/interactive.rs
+++ b/src/ui/interactive.rs
@@ -1025,9 +1025,9 @@ fn calculate_min_refresh_interval(
 }
 
 /// Parameters for auto-refresh checking
-struct AutoRefreshParams {
+struct AutoRefreshParams<'a> {
     needs_refresh: bool,
-    games: Vec<GameData>,
+    games: &'a [GameData],
     last_auto_refresh: Instant,
     auto_refresh_interval: Duration,
     min_interval_between_refreshes: Duration,
@@ -1037,7 +1037,7 @@ struct AutoRefreshParams {
 }
 
 /// Check if auto-refresh should be triggered
-fn should_trigger_auto_refresh(params: AutoRefreshParams) -> bool {
+fn should_trigger_auto_refresh(params: AutoRefreshParams<'_>) -> bool {
     if params.needs_refresh {
         return false;
     }
@@ -1068,7 +1068,7 @@ fn should_trigger_auto_refresh(params: AutoRefreshParams) -> bool {
         return true;
     }
 
-    let has_ongoing_games = has_live_games_from_game_data(&params.games);
+    let has_ongoing_games = has_live_games_from_game_data(params.games);
     let all_scheduled = !params.games.is_empty() && params.games.iter().all(is_future_game);
 
     if has_ongoing_games {
@@ -1687,7 +1687,7 @@ pub async fn run_interactive_ui(
 
         if should_trigger_auto_refresh(AutoRefreshParams {
             needs_refresh,
-            games: last_games.clone(),
+            games: &last_games,
             last_auto_refresh,
             auto_refresh_interval,
             min_interval_between_refreshes,

--- a/src/ui/interactive.rs
+++ b/src/ui/interactive.rs
@@ -1797,7 +1797,7 @@ pub async fn run_interactive_ui(
             // Update change detection variables only on successful fetch
             if !had_error {
                 last_games_hash = games_hash;
-                last_games = games.clone();
+                last_games = games;
             } else {
                 tracing::debug!(
                     "Preserving last_games due to fetch error; will retry without clearing state"

--- a/src/ui/interactive.rs
+++ b/src/ui/interactive.rs
@@ -1041,11 +1041,6 @@ fn should_trigger_auto_refresh(params: AutoRefreshParams) -> bool {
     if params.needs_refresh {
         return false;
     }
-    // If we have no games loaded, trigger a refresh to recover from empty state
-    if params.games.is_empty() {
-        tracing::debug!("Auto-refresh triggered: games list empty");
-        return true;
-    }
 
     if params.last_auto_refresh.elapsed() < params.auto_refresh_interval {
         return false;
@@ -1065,6 +1060,12 @@ fn should_trigger_auto_refresh(params: AutoRefreshParams) -> bool {
     {
         tracing::debug!("Auto-refresh skipped for historical date: {}", date);
         return false;
+    }
+
+    // After respecting timing/backoff/historical checks, recover from empty state
+    if params.games.is_empty() {
+        tracing::debug!("Auto-refresh triggered: games list empty (after guards)");
+        return true;
     }
 
     let has_ongoing_games = has_live_games_from_game_data(&params.games);

--- a/src/ui/interactive.rs
+++ b/src/ui/interactive.rs
@@ -692,8 +692,6 @@ fn would_be_previous_season(date: &str) -> bool {
         return true;
     }
 
-
-
     // For dates within the past 2 years, use more nuanced season logic
     if date_year == current_year {
         // Same year - check if we're trying to go to off-season of previous season
@@ -1796,7 +1794,9 @@ pub async fn run_interactive_ui(
 
             // Update change detection variables only on successful fetch
             if !had_error {
-                if let Some(page) = current_page.as_mut() && page.is_error_warning_active() {
+                if let Some(page) = current_page.as_mut()
+                    && page.is_error_warning_active()
+                {
                     page.hide_error_warning();
                     needs_render = true;
                 }


### PR DESCRIPTION
# Summary
Auto-refresh could stall during long-running sessions when the games list became empty or when a fetch cycle errored. This change makes the UI recover by triggering refreshes on empty state and preserving the last known data on errors, preventing the “hang” symptom.

## Motivation
* Long-running sessions sometimes stopped updating.
* API occasionally returns malformed detailed responses (e.g., missing game field), causing fetch errors.
* The event loop suppressed auto-refresh when games became empty and cleared state on errors, preventing recovery.

## Changes Made
* `src/ui/interactive.rs`
  * `should_trigger_auto_refresh`:
    * Trigger refresh when `games` is empty (previously returned early).
    * Add a debug log when triggering due to empty state.
  * `run_interactive_ui` loop:
    * Only update `last_games` and `last_games_hash` on successful fetches.
    * On errors (`had_error == true`), preserve prior state so UI keeps showing last known data and the next cycle can recover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Smarter auto-refresh: prioritizes live, unscheduled, and near-start games; also triggers when no games are listed.
  - Footer error indicator: a warning icon can be shown/hidden in teletext footers.

- Bug Fixes
  - Preserves previously shown games on fetch failures to avoid UI flicker.
  - Historical dates still suppress refresh.

- Refactor
  - Exponential retry backoff with automatic reset on success and clearer backoff logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->