### PR TITLE
refactor: replace glob re-exports with explicit imports in layout module

### DIFF
--- a/src/teletext_ui/layout/mod.rs
+++ b/src/teletext_ui/layout/mod.rs
@@ -4,16 +4,19 @@ mod ansi_cache;
 mod columns;
 mod config;
 
-pub use ansi_cache::*;
-#[allow(unused_imports)] // Items used by integration tests
-pub use columns::*;
-pub use config::*;
+#[allow(unused_imports)] // Used by integration tests
+pub use columns::AlignmentCalculator;
+pub use config::{IntelligentTruncator, LayoutConfig};
 
 use crate::data_fetcher::models::GameData;
 use std::collections::HashMap;
 
+use ansi_cache::AnsiCodeCache;
 use columns::generate_content_signature;
-use config::{ContentAnalysis, ContentCacheKey, LayoutCacheKey};
+use config::{
+    CacheStats, ContentAnalysis, ContentCacheKey, GameDataValidator, LayoutCacheKey,
+    TerminalWidthValidation, TruncationStrategy,
+};
 
 /// Manages column layout calculations for dynamic width determination
 #[derive(Debug)]
@@ -1314,6 +1317,10 @@ impl ColumnLayoutManager {
 
 #[cfg(test)]
 mod tests {
+    use super::columns::GoalTypePosition;
+    use super::config::{
+        GameDataValidator, TerminalWidthValidation, TruncationStrategy, ValidationIssueType,
+    };
     use super::*;
     use crate::data_fetcher::GoalEventData;
     use crate::teletext_ui::ScoreType;


### PR DESCRIPTION
## Summary
- Replace `pub use *;` glob re-exports in `teletext_ui::layout::mod.rs` with explicit imports
- Narrow public API surface to only the 4 types needed externally: `ColumnLayoutManager`, `LayoutConfig`, `AlignmentCalculator`, `IntelligentTruncator`
- Add explicit internal imports for types used in implementation and tests

## Test plan
- [x] `cargo test --all-features` — all 240+ tests pass
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt` — formatted
- [x] Verified all external consumers (`game_display.rs`, `rendering.rs`, `core.rs`, integration tests) still compile without changes

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined internal module exports and imports for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->